### PR TITLE
Fix: Error in createTextField()-function

### DIFF
--- a/source/designers-guide/theme-startup-guide/index.md
+++ b/source/designers-guide/theme-startup-guide/index.md
@@ -403,11 +403,11 @@ public function createConfig(Form\Container\TabContainer $container)
     );
 
     // Create the textfield
-    $textField = $this->createTextField(array(
+    $textField = $this->createTextField(
     	'basic_font_size',
     	'Basic font size',
     	'16px'
-    ));
+    );
 
     $fieldset->addElement($textField);
 


### PR DESCRIPTION
The createTextField-function does not accept an array. The correct way is to enter the strings directly as parameters.