### PR TITLE
Add service extension example for list product service and theme inherit...

### DIFF
--- a/exampleplugins/Frontend/SwagProductExtension/Bootstrap.php
+++ b/exampleplugins/Frontend/SwagProductExtension/Bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+
+use ShopwarePlugins\SwagProductExtension\StoreFrontBundle\ListProductService;
+use ShopwarePlugins\SwagProductExtension\StoreFrontBundle\SeoCategoryService;
+
+class Shopware_Plugins_Frontend_SwagProductExtension_Bootstrap
+    extends Shopware_Components_Plugin_Bootstrap
+{
+    public function getLabel()
+    {
+        return 'Produkterweiterung';
+    }
+
+    public function install()
+    {
+        $this->subscribeEvent(
+            'Enlight_Bootstrap_InitResource_shopware_storefront.seo_category_service',
+            'registerSeoCategoryService'
+        );
+
+        $this->subscribeEvent(
+            'Enlight_Bootstrap_AfterInitResource_shopware_storefront.list_product_service',
+            'registerListProductService'
+        );
+
+        $this->subscribeEvent('Enlight_Controller_Action_PostDispatchSecure_Frontend', 'addTemplateDir');
+        $this->subscribeEvent('Enlight_Controller_Action_PostDispatchSecure_Widgets',  'addTemplateDir');
+        return true;
+    }
+
+    public function afterInit()
+    {
+        $this->get('Loader')->registerNamespace(
+            'ShopwarePlugins\SwagProductExtension',
+            $this->Path()
+        );
+    }
+
+    public function addTemplateDir()
+    {
+        Shopware()->Container()->get('template')->addTemplateDir($this->Path() . 'Views/');
+    }
+
+    public function registerSeoCategoryService()
+    {
+        $seoCategoryService = new SeoCategoryService(
+            Shopware()->Container()->get('dbal_connection'),
+            Shopware()->Container()->get('shopware_storefront.category_service')
+        );
+        Shopware()->Container()->set('shopware_storefront.seo_category_service', $seoCategoryService);
+    }
+
+    public function registerListProductService()
+    {
+        Shopware()->Container()->set(
+            'shopware_storefront.list_product_service',
+            new ListProductService(
+                Shopware()->Container()->get('shopware_storefront.list_product_service'),
+                Shopware()->Container()->get('shopware_storefront.seo_category_service')
+            )
+        );
+    }
+}

--- a/exampleplugins/Frontend/SwagProductExtension/StoreFrontBundle/ListProductService.php
+++ b/exampleplugins/Frontend/SwagProductExtension/StoreFrontBundle/ListProductService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace ShopwarePlugins\SwagProductExtension\StoreFrontBundle;
+
+use Shopware\Bundle\StoreFrontBundle\Service\ListProductServiceInterface;
+use Shopware\Bundle\StoreFrontBundle\Struct;
+
+class ListProductService implements ListProductServiceInterface
+{
+    /**
+     * @var ListProductServiceInterface
+     */
+    private $service;
+
+    /**
+     * @var SeoCategoryService
+     */
+    private $seoCategoryService;
+
+    /**
+     * @param ListProductServiceInterface $service
+     * @param SeoCategoryService $seoCategoryService
+     */
+    public function __construct(ListProductServiceInterface $service, SeoCategoryService $seoCategoryService)
+    {
+        $this->service = $service;
+        $this->seoCategoryService = $seoCategoryService;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getList(array $numbers, Struct\ProductContextInterface $context)
+    {
+        $products = $this->service->getList($numbers, $context);
+
+        $categories = $this->seoCategoryService->getList($products, $context);
+
+        /**@var $product Struct\ListProduct*/
+        foreach ($products as $product) {
+            $productId = $product->getId();
+            if (!isset($categories[$productId])) {
+                continue;
+            }
+
+            $attribute = new Struct\Attribute(['category' => $categories[$productId]]);
+            $product->addAttribute('swag_seo_category', $attribute);
+        }
+        return $products;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function get($number, Struct\ProductContextInterface $context)
+    {
+        $products = $this->getList([$number], $context);
+        return array_shift($products);
+    }
+}

--- a/exampleplugins/Frontend/SwagProductExtension/StoreFrontBundle/SeoCategoryService.php
+++ b/exampleplugins/Frontend/SwagProductExtension/StoreFrontBundle/SeoCategoryService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace ShopwarePlugins\SwagProductExtension\StoreFrontBundle;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Bundle\StoreFrontBundle\Service\CategoryServiceInterface;
+use Shopware\Bundle\StoreFrontBundle\Service\Core\CategoryService;
+use Shopware\Bundle\StoreFrontBundle\Struct\Category;
+use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
+use Shopware\Bundle\StoreFrontBundle\Struct\ShopContextInterface;
+
+class SeoCategoryService
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var CategoryServiceInterface
+     */
+    private $categoryService;
+
+    /**
+     * @param Connection $connection
+     * @param CategoryServiceInterface $categoryService
+     */
+    public function __construct(Connection $connection, CategoryServiceInterface $categoryService)
+    {
+        $this->connection = $connection;
+        $this->categoryService = $categoryService;
+    }
+
+    /**
+     * @param ListProduct[] $listProducts
+     * @param ShopContextInterface $context
+     * @return Category[] indexed by product id
+     */
+    public function getList($listProducts, ShopContextInterface $context)
+    {
+        $ids = array_map(function(ListProduct $product) {
+            return $product->getId();
+        }, $listProducts);
+
+        //select all seo category ids, indexed by product id
+        $ids = $this->getCategoryIds($ids, $context);
+
+        //now select all category data for the selected ids
+        $categories = $this->categoryService->getList($ids, $context);
+
+        $result = [];
+        foreach ($ids as $productId => $categoryId) {
+            if (!isset($categories[$categoryId])) {
+                continue;
+            }
+            $result[$productId] = $categories[$categoryId];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param $ids
+     * @param $context
+     */
+    private function getCategoryIds($ids, ShopContextInterface $context)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->select(['seoCategories.article_id', 'seoCategories.category_id'])
+            ->from('s_articles_categories_seo', 'seoCategories')
+            ->andWhere('seoCategories.article_id IN (:productIds)')
+            ->andWhere('seoCategories.shop_id = :shopId')
+            ->setParameter(':shopId', $context->getShop()->getId())
+            ->setParameter(':productIds', $ids, Connection::PARAM_INT_ARRAY);
+
+        return $query->execute()->fetchAll(\PDO::FETCH_KEY_PAIR);
+    }
+}

--- a/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/CustomTheme/Theme.php
+++ b/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/CustomTheme/Theme.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Shopware\Themes\CustomTheme;
+
+use Shopware\Components\Form as Form;
+
+class Theme extends \Shopware\Components\Theme
+{
+    protected $extend = 'Responsive';
+
+    protected $name = <<<'SHOPWARE_EOD'
+Plugin theme
+SHOPWARE_EOD;
+
+    protected $description = <<<'SHOPWARE_EOD'
+Overrides the plugin template extension with own theme files
+SHOPWARE_EOD;
+
+    protected $author = <<<'SHOPWARE_EOD'
+shopware AG
+SHOPWARE_EOD;
+
+    protected $license = <<<'SHOPWARE_EOD'
+MIT
+SHOPWARE_EOD;
+
+    public function createConfig(Form\Container\TabContainer $container)
+    {
+    }
+}

--- a/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/CustomTheme/frontend/swag_product_extension/detail-link.tpl
+++ b/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/CustomTheme/frontend/swag_product_extension/detail-link.tpl
@@ -1,0 +1,5 @@
+{extends file="parent:frontend/swag_product_extension/detail-link.tpl"}
+
+{block name="frontend_swag_product_extension_detail_link_icon"}
+    <i class="icon--map"></i>
+{/block}

--- a/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/CustomTheme/frontend/swag_product_extension/listing-badge.tpl
+++ b/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/CustomTheme/frontend/swag_product_extension/listing-badge.tpl
@@ -1,0 +1,5 @@
+{extends file="parent:frontend/swag_product_extension/listing-badge.tpl"}
+
+{block name="frontend_swag_product_extension_listing_badge_category"}
+    From {$seoCategory->getName()}
+{/block}

--- a/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/SummerTheme/Theme.php
+++ b/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/SummerTheme/Theme.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Shopware\Themes\SummerTheme;
+
+use Shopware\Components\Form as Form;
+
+class Theme extends \Shopware\Components\Theme
+{
+    protected $extend = 'CustomTheme';
+
+    protected $name = <<<'SHOPWARE_EOD'
+Summer theme
+SHOPWARE_EOD;
+
+    protected $description = <<<'SHOPWARE_EOD'
+Extension of the custom theme
+SHOPWARE_EOD;
+
+    protected $author = <<<'SHOPWARE_EOD'
+shopware AG
+SHOPWARE_EOD;
+
+    protected $license = <<<'SHOPWARE_EOD'
+MIT
+SHOPWARE_EOD;
+
+    public function createConfig(Form\Container\TabContainer $container)
+    {
+    }
+}

--- a/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/SummerTheme/frontend/swag_product_extension/detail-link.tpl
+++ b/exampleplugins/Frontend/SwagProductExtension/Themes/Frontend/SummerTheme/frontend/swag_product_extension/detail-link.tpl
@@ -1,0 +1,9 @@
+{extends file="parent:frontend/swag_product_extension/detail-link.tpl"}
+
+{block name="frontend_swag_product_extension_detail_link_icon"}
+    <i class="icon--brush"></i>
+{/block}
+
+{block name="frontend_swag_product_extension_detail_link_text"}
+    Seo category: {$seoCategory->getName()}
+{/block}

--- a/exampleplugins/Frontend/SwagProductExtension/Views/frontend/detail/actions.tpl
+++ b/exampleplugins/Frontend/SwagProductExtension/Views/frontend/detail/actions.tpl
@@ -1,0 +1,8 @@
+{extends file="parent:frontend/detail/actions.tpl"}
+
+{block name='frontend_detail_actions_voucher' append}
+    {if $sArticle.attributes.swag_seo_category}
+        {$swagSeoAttribute = $sArticle.attributes.swag_seo_category}
+        {include file="frontend/swag_product_extension/detail-link.tpl" seoCategory=$swagSeoAttribute->get('category')}
+    {/if}
+{/block}

--- a/exampleplugins/Frontend/SwagProductExtension/Views/frontend/listing/product-box/product-badges.tpl
+++ b/exampleplugins/Frontend/SwagProductExtension/Views/frontend/listing/product-box/product-badges.tpl
@@ -1,0 +1,9 @@
+{extends file="parent:frontend/listing/product-box/product-badges.tpl"}
+
+{block name="frontend_listing_box_article_new" append}
+    {if $sArticle.attributes.swag_seo_category}
+        {$swagSeoAttribute = $sArticle.attributes.swag_seo_category}
+
+        {include file="frontend/swag_product_extension/listing-badge.tpl" seoCategory=$swagSeoAttribute->get('category')}
+    {/if}
+{/block}

--- a/exampleplugins/Frontend/SwagProductExtension/Views/frontend/swag_product_extension/detail-link.tpl
+++ b/exampleplugins/Frontend/SwagProductExtension/Views/frontend/swag_product_extension/detail-link.tpl
@@ -1,0 +1,15 @@
+
+{block name="frontend_swag_product_extension_detail_link"}
+    <a href="{url controller=cat sCategory=$seoCategory->getId() sPage=1}"
+       rel="nofollow"
+       class="action--link link--tell-a-friend">
+
+        {block name="frontend_swag_product_extension_detail_link_icon"}
+            <i class="icon--comment"></i>
+        {/block}
+
+        {block name="frontend_swag_product_extension_detail_link_text"}
+            {$seoCategory->getName()}
+        {/block}
+    </a>
+{/block}

--- a/exampleplugins/Frontend/SwagProductExtension/Views/frontend/swag_product_extension/listing-badge.tpl
+++ b/exampleplugins/Frontend/SwagProductExtension/Views/frontend/swag_product_extension/listing-badge.tpl
@@ -1,0 +1,7 @@
+{block name="frontend_swag_product_extension_listing_badge"}
+    <div class="product--badge badge--newcomer">
+        {block name="frontend_swag_product_extension_listing_badge_category"}
+            {$seoCategory->getName()}
+        {/block}
+    </div>
+{/block}


### PR DESCRIPTION
Decorates the shopware_storefront.list_product_service, to add seo categories as attribute to each ListProduct and displays a small bage on listing and detail page.

Additionally there are two themes which overrides the plugin extension.
I hope this can help you to get started with shopware plugin development.
