### PR TITLE
Link fix

### DIFF
--- a/source/developers-guide/rest-api/api-resource-orders/index.md
+++ b/source/developers-guide/rest-api/api-resource-orders/index.md
@@ -45,7 +45,7 @@ This API call requires one of the following parameters to be defined:
 |-----------------------|-----------------------|-------------------------------------------------------------------------------|
 | id				    | integer (primary key) | 							                                                    |
 | number				| string				|																				|
-| customerId			| integer (foreign key) | **[Customer](./api-resource-customer)**										|
+| customerId			| integer (foreign key) | **[Customer](../api-resource-customer)**										|
 | paymentId				| integer (foreign key)	| **[PaymentData](../models/#payment-data)**										|
 | dispatchId			| integer (foreign key)	| **[Dispatch](../models/#dispatch)**											|
 | partnerId				| integer (foreign key)	|    																			|


### PR DESCRIPTION
The customerID Original Object links to `https://developers.shopware.com/developers-guide/rest-api/api-resource-orders/api-resource-customer`.

Correct Link would be `https://developers.shopware.com/developers-guide/rest-api/api-resource-customer/`