### PR TITLE
Remove tutorial section

### DIFF
--- a/source/developers-guide/index.html
+++ b/source/developers-guide/index.html
@@ -16,6 +16,7 @@ github_link: developers-guide/index.html
     <li><a href="{{ site.url }}/developers-guide/shopware-5-cli-commands/">CLI commands</a></li>
     <li><a href="{{ site.url }}/developers-guide/controller/">Shopware controllers</a></li>
     <li><a href="{{ site.url }}/developers-guide/services/">Plugin services</a></li>
+    <li><a href="{{ site.url }}/developers-guide/digital-publishing-elements/">Create custom elements for the Digital Publishing module</a></li>
 </ul>
 
 <h1>General resources</h1>
@@ -29,9 +30,4 @@ github_link: developers-guide/index.html
     <li><a href="{{ site.url }}/blog/2015/06/09/understanding-the-shopware-hook-system/">The Shopware hook system</a></li>
     <li><a href="{{ site.url }}/blog/2015/02/11/understanding-the-shopware-http-cache/">The Shopware HTTP cache</a></li>
     <li><a href="{{ site.url }}/blog/2015/08/11/the-shopware-seo-engine/">The Shopware SEO engine</a></li>
-</ul>
-
-<h1>Tutorials</h1>
-<ul>
-    <li><a href="{{ site.url }}/developers-guide/digital-publishing-elements/">Create custom elements for the Digital Publishing module</a></li>
 </ul>


### PR DESCRIPTION
I suggest to remove the tutorial section again - guides like this have been added to the "plugin resources" before - if we want to have a "tutorial" section, we should still move the existing "tutorial-like" guides to there - e.g. store front components, password encoder, plugin quick start.