### PR TITLE
Fixed PHP7 compatibility

### DIFF
--- a/source/developers-guide/backend-components/basics/index.md
+++ b/source/developers-guide/backend-components/basics/index.md
@@ -101,7 +101,7 @@ class Shopware_Plugins_Backend_SwagProduct_Bootstrap extends Shopware_Components
             'class' => 'sprite-application-block',
             'action' => 'Index',
             'active' => 1,
-            'parent' => $this->Menu()->findOneBy('label', 'Marketing')
+            'parent' => $this->Menu()->findOneBy(['label' => 'Marketing'])
         ));
         return true;
     }

--- a/source/developers-guide/lightweight-backend-modules/index.md
+++ b/source/developers-guide/lightweight-backend-modules/index.md
@@ -99,7 +99,7 @@ $this->createMenuItem(array(
     'onclick' => 'createSimpleModule("ExampleModulePlainHtml", { "title": "Plain HTML Module" })',
     'class' => 'sprite-star',
     'active' => 1,
-    'parent' => $this->Menu()->findOneBy('label', 'Einstellungen')
+    'parent' => $this->Menu()->findOneBy(['label' => 'Einstellungen'])
 ));
 ```
 


### PR DESCRIPTION
Installing a plugin with the 2-parameter-call results in an `E_RECOVERABLE_ERROR`. We should provide an key/value array.