### PR TITLE
Added version history for articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,21 @@ If you want, you can customize the behavior of the toc list as well. You can def
 ```
 <div class="toc-list" data-depth="1" data-headline="Awesome table of contents"></div>
 ```
+
+## Version History
+To create a version history table, you simply have to add a `history` array to your metadata.
+
+Example:
+```
+
+---
+layout: default
+indexed: true
+...
+history:
+  2015-11-16: creation
+  2015-11-23: added frontend documentation
+  2016-01-01: documented millenium bug
+---
+
+```

--- a/source/_layouts/default.twig.html
+++ b/source/_layouts/default.twig.html
@@ -86,6 +86,26 @@
             {% endif %}
 
             {% block content_wrapper %}{% block content %}{% endblock %}{% endblock %}
+
+            {% if page.history is defined %}
+            <h2>Version History</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Changes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for changeDate, changeText in page.history|reverse(true) %}
+                    <tr>
+                        <td>{{ changeDate|date("Y-m-d") }}</td>
+                        <td>{{ changeText }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            {% endif %}
         </div>
 
         <div class="clearfix"></div>


### PR DESCRIPTION
I think that it is neccessary to provide developers with a version history of a document.

**Example: CSRF Protection**
Currently, the article describes how the protection works in general and how it has been implemented in the backend. 

What if we document the frontend implementation or do changes to the current backend implementation? How does a developer know, when and what has changed since he last visited this article?

For that reason, i've implemented a new meta tag called `history`. It's a simple key/value array whereas the key is the date of change, syntax `yyyy-mm-dd`, and the value is a short summary of the changes. So the meta tag could be used like this:

```
history:
  2015-11-16: creation
  2015-11-23: added frontend documentation
  2016-01-01: documented millenium bug
``` 

This will render a new `<h1>`  tag right below the article with a simple `<table>` which looks like this:

Date | Changes
-------|-------------
2016-01-01 | documented millenium bug
2015-11-23 | added frontend documentation
2015-11-16 | creation