### PR TITLE
adding http_user_agent to curl request

### DIFF
--- a/source/developers-guide/rest-api/index.md
+++ b/source/developers-guide/rest-api/index.md
@@ -64,6 +64,7 @@ class ApiClient {
         $this->cURL = curl_init();
         curl_setopt($this->cURL, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($this->cURL, CURLOPT_FOLLOWLOCATION, false);
+        curl_setopt($this->cURL, CURLOPT_USERAGENT, 'Shopware ApiClient');
         curl_setopt($this->cURL, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
         curl_setopt($this->cURL, CURLOPT_USERPWD, $username . ':' . $apiKey);
         curl_setopt($this->cURL, CURLOPT_HTTPHEADER, array(


### PR DESCRIPTION
in some server configurations the web server rejects http requests without an http user agent. Some kind of annoying troubleshooting why it works with a BrowserRequest but not with an php script ;-)