### PR TITLE
Added demo plugin for the lightweight backend modules guide

### DIFF
--- a/source/developers-guide/lightweight-backend-modules/index.md
+++ b/source/developers-guide/lightweight-backend-modules/index.md
@@ -229,5 +229,9 @@ Here's a entire list of all available events:
 * component/toggle-maximize
 * component/set-body-style
 
+## Demo plugin
+A demo plugin which highlights the new functionality can be found on Github in our ["shopwareLabs" repository](https://github.com/shopwareLabs/SwagLightweightModule).
+
+
 ## API documentation
 You can find the API documentation of the our <a href="{{ site.url }}/developers-guide/lightweight-backend-modules-api/" target="_blank">postMessage API here</a>.


### PR DESCRIPTION
Added a small section which links to the newly published demo plugin for the lightweight backend modules.