### PR TITLE
Add remove version tag to documents

### DIFF
--- a/source/_layouts/default.twig.html
+++ b/source/_layouts/default.twig.html
@@ -67,10 +67,17 @@
 
             <div class="info">
 
-                {% if page.shopware_version %}
-                <span class="version clearfix" data-shopware-version="{{ page.shopware_version }}">
-                    <span class="versionDisc">as of version</span>
-                    <span class="versionBadge">{{ page.shopware_version }}</span>
+                {% if page.until_version %}
+                <span class="version clearfix" data-until-version="{{ page.until_version }}">
+                    <span class="versionDisc">Removed in version</span>
+                    <span class="versionBadge">{{ page.until_version }}</span>
+                </span>
+                {% endif %}
+
+                {% if page.from_version %}
+                <span class="version clearfix" data-from-version="{{ page.from_version }}">
+                    <span class="versionDisc">From version</span>
+                    <span class="versionBadge">{{ page.from_version }}</span>
                 </span>
                 {% endif %}
 

--- a/source/designers-guide/best-practice-theme-development/index.md
+++ b/source/designers-guide/best-practice-theme-development/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Best practice theme development
 github_link: designers-guide/best-practice-theme-development/index.md
-shopware_version: 5.0.1
+from_version: 5.0.1
 indexed: true
 redirect:
   - /designers-guide/using-grunt/

--- a/source/designers-guide/how-to-use-karma/index.md
+++ b/source/designers-guide/how-to-use-karma/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: How to use Karma for storefront tests
 github_link: designers-guide/how-to-use-karma/index.md
-shopware_version: 5.0.3
+from_version: 5.0.3
 indexed: true
 ---
 

--- a/source/designers-guide/managing-third-party-dependencies-with-npm/index.md
+++ b/source/designers-guide/managing-third-party-dependencies-with-npm/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Managing third-party dependencies with npm
 github_link: designers-guide/managing-third-party-dependencies-with-npm/index.md
-shopware_version: 5.2
+from_version: 5.2
 indexed: true
 ---
 

--- a/source/designers-guide/modify-jquery-plugins/index.md
+++ b/source/designers-guide/modify-jquery-plugins/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Modify jQuery plugins 
 github_link: designers-guide/modify-jquery-plugins/index.md
-shopware_version: 5.0.2
+from_version: 5.0.2
 indexed: true
 ---
 

--- a/source/designers-guide/range-slider-algorithm/index.md
+++ b/source/designers-guide/range-slider-algorithm/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Choosing the right range slider algorithm
 github_link: designers-guide/range-slider-algorithm/index.md
-shopware_version: 5.0.3
+from_version: 5.0.3
 indexed: true
 ---
 

--- a/source/developers-guide/digital-publishing-elements/index.md
+++ b/source/developers-guide/digital-publishing-elements/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Digital Publishing Elements
 github_link: developers-guide/digital-publishing-elements/index.md
-shopware_version: 5.1.0
+from_version: 5.1.0
 indexed: true
 tags:
   - Digital Publishing

--- a/source/developers-guide/elasticsearch/index.md
+++ b/source/developers-guide/elasticsearch/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Elasticsearch development
 github_link: developers-guide/elasticsearch/index.md
-shopware_version: 5.1.0
+from_version: 5.1.0
 indexed: true
 tags:
   - performance

--- a/source/developers-guide/http-cache/index.md
+++ b/source/developers-guide/http-cache/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Shopware HTTP cache
 github_link: developers-guide/http-cache/index.md
-shopware_version: 5.1.2
+from_version: 5.1.2
 indexed: true
 redirect:
   - /blog/2015/12/04/working-with-the-http-cache/index.html

--- a/source/developers-guide/lightweight-backend-modules-api/index.md
+++ b/source/developers-guide/lightweight-backend-modules-api/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Lightweight backend modules api
 github_link: developers-guide/lightweight-backend-modules-api/index.md
-shopware_version: 5.1.0
+from_version: 5.1.0
 indexed: true
 ---
 

--- a/source/developers-guide/lightweight-backend-modules/index.md
+++ b/source/developers-guide/lightweight-backend-modules/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Lightweight backend modules
 github_link: developers-guide/lightweight-backend-modules/index.md
-shopware_version: 5.1.0
+from_version: 5.1.0
 indexed: true
 ---
 

--- a/source/developers-guide/risk-rules/index.md
+++ b/source/developers-guide/risk-rules/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Custom Risk Rules
 github_link: developers-guide/risk-rules/index.md
-shopware_version: 5.1.2
+from_version: 5.1.2
 indexed: true
 ---
 

--- a/source/developers-guide/shopware-5-media-service/index.md
+++ b/source/developers-guide/shopware-5-media-service/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: MediaService
 github_link: developers-guide/shopware-5-media-service/index.md
-shopware_version: 5.1.0
+from_version: 5.1.0
 indexed: true
 history:
     2015-09-08: creation

--- a/source/sysadmins-guide/elasticsearch-setup/index.md
+++ b/source/sysadmins-guide/elasticsearch-setup/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Elasticsearch setup
 github_link: sysadmins-guide/elasticsearch-setup/index.md
-shopware_version: 5.1.0
+from_version: 5.1.0
 tags:
   - performance
   - elasticsearch


### PR DESCRIPTION
This comes to me as a consequence of "Managing third-party dependencies with npm", which seems to replace "Managing third-party dependencies with bower". We already have a tag to identify in which SW version a certain feature was introduced, and it only makes sense that we flag old features as removed/deprecated.

This still needs a bit of CSS fixes. If both "from version" and "until version" are present, the title gets squashed to the left of the page. @klarstil can you take care of it, please?
