### PR TITLE
Fixed translations api doc

### DIFF
--- a/source/developers-guide/rest-api/api-resource-translation/index.md
+++ b/source/developers-guide/rest-api/api-resource-translation/index.md
@@ -34,8 +34,8 @@ You can retrieve data of translations by providing the specific id
 | type 	         	  | string				  |                                                 |
 | data		      	  | array				  | 		                                        |
 | key				  | integer 			  | 												|
-| localeId	      	  | integer (foreign key) | **[Locale](../models/#locale)**                  |
-| locale			  | object				  | **[Locale](../models/#locale)**					|
+| shopId              | integer (foreign key) | **[Shop](../models/#shop)**                     |
+| shop			      | object				  | **[Shop](../models/#shop)**                     |
 
 *Since this returns a list, the following fields will be added to the array:*
 
@@ -70,7 +70,7 @@ You can use this data to add a new translation to the shop
 | type 	         	  | string				  |                                                 |
 | data		      	  | array				  | 		                                        |
 | key				  | integer 			  | 												|
-| localeId	      	  | integer (foreign key) | **[Locale](../models/#locale)**                  |
+| shopId	      	  | integer (foreign key) | **[Shop](../models/#shop)**                     |
 
 You can post or put data by sending the following data to this URL:
 


### PR DESCRIPTION
Since Shopware 5.0.0 the translation api expects a shopId (instead of a localeId) ..