### PR TITLE
Updated highlight.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /app/config/sculpin_kernel_*.yml
 /app/logs/*
 /output_*/
-/source/components/
 /source/assets/css/_imports/*.css
 /source/assets/css/basic.css
 /deploy_key

--- a/composer.json
+++ b/composer.json
@@ -5,16 +5,11 @@
     "sculpin/sculpin-theme-composer-plugin": "@dev",
     "dflydev/embedded-composer-console": "@dev",
     "dflydev/embedded-composer-core": "@dev",
-    "robloach/component-installer": "dev-master",
-    "components/highlightjs": "~8.4.0",
     "bcremer/sculpin-less-bundle": "~0.1",
     "mavimo/sculpin-redirect-bundle": "@dev",
     "bcremer/sculpin-commonmark-bundle": "^0.4.0",
     "webuni/commonmark-table-extension": "^0.4.0",
     "algolia/algoliasearch-client-php": "^1.6"
-  },
-  "config": {
-    "component-dir": "source/components"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a9004902c9848b41ead49a8b1feb5940",
-    "content-hash": "c5f7c4a113384e495ab1e3f91ee96d11",
+    "hash": "c52f8a5676c308447c1e2660b60477ab",
+    "content-hash": "34988d46af2d15f4441294917eca1e2f",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
-            "version": "1.8.2",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algolia/algoliasearch-client-php.git",
-                "reference": "2166501dfc0efa16c205c1e5b43487a7e325ae63"
+                "reference": "06bc47a5024cfeea5e475f1abd4516cd5bf4fad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/2166501dfc0efa16c205c1e5b43487a7e325ae63",
-                "reference": "2166501dfc0efa16c205c1e5b43487a7e325ae63",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/06bc47a5024cfeea5e475f1abd4516cd5bf4fad6",
+                "reference": "06bc47a5024cfeea5e475f1abd4516cd5bf4fad6",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
             ],
             "description": "Algolia Search API Client for PHP",
             "homepage": "https://github.com/algolia/algoliasearch-client-php",
-            "time": "2016-05-05 12:48:06"
+            "time": "2016-05-10 21:01:23"
         },
         {
             "name": "bcremer/sculpin-commonmark-bundle",
@@ -143,48 +143,6 @@
                 "sculpin"
             ],
             "time": "2015-06-08 07:43:05"
-        },
-        {
-            "name": "components/highlightjs",
-            "version": "8.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/components/highlightjs.git",
-                "reference": "f27b85bc25d6c70c69347e77193688ec562ce2eb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/components/highlightjs/zipball/f27b85bc25d6c70c69347e77193688ec562ce2eb",
-                "reference": "f27b85bc25d6c70c69347e77193688ec562ce2eb",
-                "shasum": ""
-            },
-            "type": "component",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "highlight.pack.js"
-                    ],
-                    "files": [
-                        "styles/*"
-                    ],
-                    "shim": {
-                        "exports": "hljs"
-                    }
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Ivan Sagalaev",
-                    "email": "maniac@softwaremaniacs.org",
-                    "homepage": "http://softwaremaniacs.org"
-                }
-            ],
-            "description": "Highlight.js highlights syntax in code examples on blogs, forums and in fact on any web pages.",
-            "time": "2014-12-10 02:08:20"
         },
         {
             "name": "composer/composer",
@@ -1141,83 +1099,6 @@
             "time": "2016-01-25 15:43:01"
         },
         {
-            "name": "kriswallsmith/assetic",
-            "version": "v1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kriswallsmith/assetic.git",
-                "reference": "9928f7c4ad98b234e3559d1049abd13387f86db5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kriswallsmith/assetic/zipball/9928f7c4ad98b234e3559d1049abd13387f86db5",
-                "reference": "9928f7c4ad98b234e3559d1049abd13387f86db5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.1",
-                "symfony/process": "~2.1|~3.0"
-            },
-            "conflict": {
-                "twig/twig": "<1.23"
-            },
-            "require-dev": {
-                "cssmin/cssmin": "3.0.1",
-                "joliclic/javascript-packer": "1.1",
-                "kamicane/packager": "1.0",
-                "leafo/lessphp": "^0.3.7",
-                "leafo/scssphp": "~0.1",
-                "mrclay/minify": "~2.2",
-                "patchwork/jsqueeze": "~1.0|~2.0",
-                "phpunit/phpunit": "~4.8",
-                "psr/log": "~1.0",
-                "ptachoire/cssembed": "~1.0",
-                "symfony/phpunit-bridge": "~2.7|~3.0",
-                "twig/twig": "~1.8|~2.0"
-            },
-            "suggest": {
-                "leafo/lessphp": "Assetic provides the integration with the lessphp LESS compiler",
-                "leafo/scssphp": "Assetic provides the integration with the scssphp SCSS compiler",
-                "leafo/scssphp-compass": "Assetic provides the integration with the SCSS compass plugin",
-                "patchwork/jsqueeze": "Assetic provides the integration with the JSqueeze JavaScript compressor",
-                "ptachoire/cssembed": "Assetic provides the integration with phpcssembed to embed data uris",
-                "twig/twig": "Assetic provides the integration with the Twig templating engine"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Assetic": "src/"
-                },
-                "files": [
-                    "src/functions.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kris Wallsmith",
-                    "email": "kris.wallsmith@gmail.com",
-                    "homepage": "http://kriswallsmith.net/"
-                }
-            ],
-            "description": "Asset Management for PHP",
-            "homepage": "https://github.com/kriswallsmith/assetic",
-            "keywords": [
-                "assets",
-                "compression",
-                "minification"
-            ],
-            "time": "2015-11-12 13:51:40"
-        },
-        {
             "name": "league/commonmark",
             "version": "0.13.2",
             "source": {
@@ -1706,54 +1587,6 @@
                 "stream"
             ],
             "time": "2012-12-14 00:58:14"
-        },
-        {
-            "name": "robloach/component-installer",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/RobLoach/component-installer.git",
-                "reference": "0912e09cb1b79de1ebb76becbeb37c3b70937b52"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/RobLoach/component-installer/zipball/0912e09cb1b79de1ebb76becbeb37c3b70937b52",
-                "reference": "0912e09cb1b79de1ebb76becbeb37c3b70937b52",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0",
-                "kriswallsmith/assetic": "1.*",
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "composer/composer": "1.*@alpha",
-                "phpunit/phpunit": "4.*"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                },
-                "class": "ComponentInstaller\\ComponentInstallerPlugin"
-            },
-            "autoload": {
-                "psr-0": {
-                    "ComponentInstaller": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Rob Loach",
-                    "homepage": "http://robloach.net"
-                }
-            ],
-            "description": "Allows installation of Components via Composer.",
-            "time": "2016-04-18 13:37:04"
         },
         {
             "name": "sculpin/sculpin",
@@ -3122,7 +2955,6 @@
         "sculpin/sculpin-theme-composer-plugin": 20,
         "dflydev/embedded-composer-console": 20,
         "dflydev/embedded-composer-core": 20,
-        "robloach/component-installer": 20,
         "mavimo/sculpin-redirect-bundle": 20
     },
     "prefer-stable": false,

--- a/source/_layouts/default.twig.html
+++ b/source/_layouts/default.twig.html
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#26556f">
 
     <link href='//fonts.googleapis.com/css?family=Open+Sans:700,600,400' rel='stylesheet' type='text/css'>
-    <link href="{{ site.url }}/components/highlightjs/styles/{{ versioned('github.css') }}" rel="stylesheet"/>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/github-gist.min.css">
     <link href="{{ site.url }}/{{ versioned(theme_path('assets/css/basic.css')) }}" rel="stylesheet" media="screen">
 
     <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/blog/atom.xml"
@@ -127,7 +127,8 @@
 
 <script src="//cdn.jsdelivr.net/jquery/2.1.4/jquery.min.js"></script>
 <script src="//cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
-<script src="{{ site.url }}/components/highlightjs/{{ versioned('highlight.pack.js') }}"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/languages/less.min.js"></script>
 <script src="{{ site.url }}/{{ versioned(theme_path('assets/js/anchor.min.js')) }}"></script>
 <script src="{{ site.url }}/{{ versioned(theme_path('assets/js/jquery.expandCode.js')) }}"></script>
 <script src="{{ site.url }}/{{ versioned(theme_path('assets/js/jquery.toc.js')) }}"></script>

--- a/source/designers-guide/custom-listing-page/index.md
+++ b/source/designers-guide/custom-listing-page/index.md
@@ -36,7 +36,7 @@ Then we extend our new template from `frontend/listing/index.tpl`:
 
 We will add some custom LESS/CSS modifications later. Therefore, we add a wrapping element with an individual `custom-detail` class as a container class:
 
-```smarty
+```html
 {block name='frontend_index_content'}
     <div class="custom-listing">
         {$smarty.block.parent}
@@ -55,7 +55,7 @@ We will add some custom LESS/CSS modifications later. Therefore, we add a wrappi
 
 We will manually exclude the `sidebar` and the `topseller-slider` from our custom listing template by overwriting the specific blocks with empty content. These are the blocks that contain the specific definitions:
 
-```smarty
+```html
 {block name='frontend_index_content_left'}
 {/block}
 
@@ -67,13 +67,13 @@ We will manually exclude the `sidebar` and the `topseller-slider` from our custo
 
 We want to overwrite the default CMS content output of the listing and implement some custom markup and styling to it. This is the original block we will overwrite to add our new CMS markup:
 
-```smarty
+```html
 {block name="frontend_listing_index_text"}
 ```
 
 The CMS content that can be added to a category in the backend is optional, so in order to not display an empty element if no content is added, we will create a prompt that checks if the `cmsHeadline` or `cmsText` contain any information.
 
-```smarty
+```html
 {if $sCategoryContent.cmsHeadline || $sCategoryContent.cmsText}
     <div class="custom-listing--intro">
         <h1 class="intro--cmsHeadline">{$sCategoryContent.cmsHeadline}</h1>
@@ -107,19 +107,19 @@ We will simply overwrite the default listing block and add our own iteration thr
 
 The new product box is separated into its own `box-custom.tpl` file and extends the default `box-basic` product box of the bare theme. When we added the `{extends}` command of Smarty and chose the correct path, we can now overwrite every part of the product box inside our newly created file:
 
-```smarty
+```html
 {extends file="parent:frontend/listing/product-box/box-basic.tpl"}
 ```
 
 When we take a look at the `box-basic.tpl` file of the bare theme, we can find the `frontend_listing_box_article` block that contains the whole content of the product box. We will take that block and overwrite it completely:
 
-```smarty
+```html
 {block name="frontend_listing_box_article_content"}
 ```
 
 After defining the block we are ready to add some markup to our template file. We can adopt the `box--content` element and the helper class `is--rounded` that adds a border radius to the product box. Inside the `box--content` element we will add an `<a>`, which will later be the hovering layer. We also add some additional information like the `articleName` and `price` properties. The article image will be included from the bare theme with the `{include file="parent: ... "}` tag, with which you can import partials of the inherited theme:
 
-```smarty
+```html
 <div class="box--content is--rounded">
     <a class="box-custom--info" href="{$sArticle.linkDetails|rewrite:$sArticle.articleName}">
         <div class="info--wrapper">

--- a/source/designers-guide/find-smarty-blocks/index.md
+++ b/source/designers-guide/find-smarty-blocks/index.md
@@ -132,7 +132,7 @@ Now let's work on a real-world example. Let's say we want to remove the comment 
 
 Now we have found the Smarty block named ```frontend_blog_detail_comments``` and we can overwrite it in our theme like this:
 
-```smarty
+```html
 {extends file="parent:frontend/blog/detail.tpl"}
 
 {* Remove the comment section *}
@@ -146,7 +146,7 @@ We've classified widgets as a separate section in Shopware, which means that the
 
 You might see a call to the Smarty ```action``` plugin in a template file like this:
 
-```smarty
+```html
 {action module=widgets controller=listing action=tag_cloud sController=index}
 ```
 

--- a/source/designers-guide/responsive-images/index.md
+++ b/source/designers-guide/responsive-images/index.md
@@ -25,14 +25,14 @@ The Shopware 5 media manager allows you to upload pictures with large file sizes
 ### Basic image
 This example is the Shopware 5 equivalent to the basic `<img src="">` tag. Instead of applying the `src` attribute, we now have the opportunity to use the `srcset`, which allows us to specify the original thumbnail and its high dpi optimized version in the same attribute. Depending on the screen density, one of the two pictures is displayed. In convention the high dpi display image names are suffixed with a `@2x`.
 
-```smarty
+```html
 <img srcset="product.jpg, product@2x.jpg 2x" alt="Produktfoto">
 ```
 
 ### Picture element
 The `picture` element takes the term "responsive" even a little step further. It is part of the [official W3C standard](http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-picture-element "W3C picture element specifications") and is supported by most of the latest browsers. To ensure support for outdated browsers we are using the `picturefill.js` polyfill. Inside the `picture` element we can define multiple image sources and determine their visibility using a media query like syntax in the `media` attribute. In other words, we can choose which image is displayed at which viewport size. This fits perfectly well with the thumbnails that the thumbnail generator is able to create. The `picture` element also contains a default `img` tag, in cases the `media` attributes do not match the browser viewport.
 
-```smarty
+```html
 <picture>
     <source media="(min-width: 64em)" srcset="product-large.jpg, product-large@2x.jpg 2px">
     <source media="(min-width: 48em)" srcset="product-medium.jpg, product-medium@2px.jpg 2px">

--- a/source/developers-guide/shopware-5-media-service/index.md
+++ b/source/developers-guide/shopware-5-media-service/index.md
@@ -57,7 +57,7 @@ $url = $mediaService->getUrl($thumbnailPath);
 
 In your Smarty templates you may use the `{media path=...}` expression to get the fully qualified URL.
 
-```smarty
+```html
 <img src="{media path="media/image/my-fancy-image.png"}">
 ```
 

--- a/source/developers-guide/shopware-5-plugin-update-guide/index.md
+++ b/source/developers-guide/shopware-5-plugin-update-guide/index.md
@@ -46,7 +46,7 @@ class Shopware_Plugins_Frontend_SwagExample1_Bootstrap extends Shopware_Componen
 ```
 
 #### SwagExample1/Views/frontend/detail/example1.tpl
-```smarty
+```html
 {block name="frontend_detail_index_detail"}
     {block name="frontend_detail_example"}
         <div class="example--own-topseller">
@@ -83,7 +83,7 @@ First, the template structure is revised. The example1.tpl file is now divided i
 
 The new files contain the following source code:
 #### SwagExample1/Views/common/frontend/swag_example1/detail_extension.tpl
-```smarty
+```html
 {block name="frontend_detail_example"}
     <div class="example--own-topseller">
         {block name="frontend_detail_example_headline"}
@@ -104,14 +104,14 @@ The new files contain the following source code:
 ```
 
 #### SwagExample1/Views/emotion/frontend/detail/example1.tpl
-```smarty
+```html
 {block name="frontend_detail_index_detail"}
     {include file="frontend/swag_example1/detail_extension.tpl"}
 {/block}
 ```
 
 #### SwagExample1/Views/responsive/frontend/detail/index.tpl
-```smarty
+```html
 {extends file="parent:frontend/detail/index.tpl"}
 
 {block name="frontend_detail_index_detail"}
@@ -342,19 +342,19 @@ If you want to display message to the shop customer, you can use the __messages_
 Examples:
 
 ##### account/password.tpl - Display a success message.
-```smarty
+```html
 {include file="frontend/_includes/messages.tpl" type="success" content="{s name='PasswordInfoSuccess'}{/s}"}
 ```
 ![Success Message](message-success.png)
 
 ##### account/orders.tpl - Display a warning message.
-```smarty
+```html
 {include file="frontend/_includes/messages.tpl" type="warning" content="{s name='OrdersInfoEmpty'}{/s}"}
 ```
 ![Warning Message](message-warning.png)
 
 ##### blog/comment/form.tpl - Display an error message
-```smarty
+```html
 {include file="frontend/_includes/messages.tpl" type="error" content="{s name='BlogInfoFailureFields'}{/s}"}
 ```
 ![Error Message](message-error.png)
@@ -635,7 +635,7 @@ class Shopware_Plugins_Frontend_SwagExample1_Bootstrap extends Shopware_Componen
 ```
 
 #### SwagExample1/Views/common/frontend/swag_example1/detail_extension.tpl
-```smarty
+```html
 {block name="frontend_detail_example"}
     <div class="example--own-topseller">
         {block name="frontend_detail_example_headline"}
@@ -656,14 +656,14 @@ class Shopware_Plugins_Frontend_SwagExample1_Bootstrap extends Shopware_Componen
 ```
 
 #### SwagExample1/Views/emotion/frontend/detail/example1.tpl
-```smarty
+```html
 {block name="frontend_detail_index_detail"}
     {include file="frontend/swag_example1/detail_extension.tpl"}
 {/block}
 ```
 
 #### SwagExample1/Views/responsive/frontend/detail/index.tpl
-```smarty
+```html
 {extends file="parent:frontend/detail/index.tpl"}
 
 {block name="frontend_detail_index_detail"}


### PR DESCRIPTION
This PR replaces the packaged highlight.js with the current one using a CDN. Because there is a custom smarty parser, the code have been changed to html.