### PR TITLE
Make the styling of code simpler

### DIFF
--- a/source/assets/css/_imports/codeExpand.less
+++ b/source/assets/css/_imports/codeExpand.less
@@ -6,7 +6,6 @@ pre code {
 
 .code-expandButton {
     background-color: #E8E8E8;
-    border: 1px solid #d8d8d8;
     bottom: 0;
     color: #777777;
     cursor: pointer;
@@ -21,10 +20,10 @@ pre code {
     text-align: center;
     width: 15%;
     z-index: 100;
+    border-bottom-right-radius: 3px;
 }
 .code-expandButton:hover {
     background-color: #d8d8d8;
-    border-color: #c8c8c8;
     color: #555;
 }
 

--- a/source/assets/css/basic.less
+++ b/source/assets/css/basic.less
@@ -411,32 +411,38 @@ input#search-query {
     min-height: 800px;
     min-height: 80vh;
 
-    code.hljs {
+    code.hljs,
+    pre > code.language-nohighlight {
         background: #fafafa;
-        border: 1px solid #d8d8d8;
+        border-radius: 3px;
         font-size: 14px;
+        padding: 16px;
         font-family: "Consolas", "Monaco", "DejaVu Sans Mono", "Courier New", sans-serif;
     }
-    code:not(.hljs) {
-        margin: 0 2px;
-        padding: 0 5px;
-        white-space: nowrap;
-        border: 1px solid #eaeaea;
-        background-color: #fafafa;
+    code:not(.hljs):not(.language-nohighlight) {
+
+        &::before {
+            letter-spacing: -0.2em;
+            content: "\00a0";
+        }
+
+        &::after {
+            letter-spacing: -0.2em;
+            content: "\00a0";
+        }
+
+        padding: 0.2em 0;
+        background-color: rgba(0,0,0,.04);
         border-radius: 3px;
         font-family: "Consolas", "Monaco", "DejaVu Sans Mono", "Courier New", sans-serif;
         color: #333;
         font-size: 13px;
+        word-wrap: break-word;
     }
 
     pre > code.language-nohighlight {
-        padding: 7px;
         white-space: pre;
         display: block;
-        background: #fafafa;
-        border: 1px solid #d8d8d8;
-        font-size: 14px;
-        font-family: "Consolas", "Monaco", "DejaVu Sans Mono", "Courier New", sans-serif;
     }
 
     #search input {

--- a/source/developers-guide/address-management-guide/index.md
+++ b/source/developers-guide/address-management-guide/index.md
@@ -1,0 +1,57 @@
+---
+layout: default
+title: Address Management Guide
+github_link: developers-guide/address-management-guide/index.md
+shopware_version: 5.2.0
+indexed: true
+tags:
+  - address
+  - management
+  - services
+---
+
+The address management allows a customer to manage more than only one address which gets changed with every order. The customer is now able to create more address, e.g. for home and work, and use them later on in an order without loosing all existing address data. He can just change the reference to the default billing address, instead of changing it entirely.
+
+# The address service
+
+The address service is used to manage all address entities in Shopware. It only works with models which makes it easy to comprehend, which properties are available and can be used. To know which properties are available, please refer to the model `\Shopware\Models\Customer\Address` in our source code.
+
+## Creation
+
+Like said above, you have to pass an already complete address model and an existing customer to the address service. In case of a validation error or other errors, you'll get an exception.
+
+**Example**
+
+```php
+<?php
+$customer = $this->get('models')->find(Customer::class, 1);
+
+$address = new Address();
+$address->fromArray($addressData);
+
+$this->get('shopware_account.address_service')->create($address, $customer);
+```
+
+
+
+# Changes
+
+
+
+**Example: Extending the address form**
+
+```php
+<?php
+$this->subscribeEvent('Shopware_Form_Builder', function(\Enlight_Event_EventArgs $event) {
+    if ($event->getReference() !== AddressFormType::class) {
+        return;
+    }
+
+    /** @var \Symfony\Component\Form\FormBuilderInterface $builder */
+    $builder = $event->getBuilder();
+
+    $builder->add('addressLine3', TextType::class, [
+        'constraints' => [new NotBlank()]
+    ]);
+});
+```


### PR DESCRIPTION
This is just a styling update which, in my opinion, is more readable and makes an cleaner look overall. This is only related to `<code>` blocks.

I've removed the border, increased the padding and modified the expand button to fit the code styling.

### before
![before](https://cloud.githubusercontent.com/assets/736986/15320944/a85f4d28-1c33-11e6-8fe3-a9ac2914e6a7.png)

### after
![after](https://cloud.githubusercontent.com/assets/736986/15320943/a85f0138-1c33-11e6-98bf-de749afc2c65.png)
