### PR TITLE
Fix links from API example pages to corresponding resource pages.

### DIFF
--- a/source/developers-guide/rest-api/examples/article/index.md
+++ b/source/developers-guide/rest-api/examples/article/index.md
@@ -8,7 +8,7 @@ indexed: false
 ## Introduction
 
 In this article, you will find examples of the article resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
-Please read the page covering the **[article API resource](../api-resource-article)** if you haven't yet, to get more information about the article resource and the data it provides.
+Please read the page covering the **[article API resource](/developers-guide/rest-api/api-resource-article/)** if you haven't yet, to get more information about the article resource and the data it provides.
 
 These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-a)**. One of its advantages is that, instead of providing query arguments directly in the URL, you can do so by means of method argument. The client application will, internally, handle the full URL generation. You can also place variables using this technique. An example call would look like this:
 

--- a/source/developers-guide/rest-api/examples/category/index.md
+++ b/source/developers-guide/rest-api/examples/category/index.md
@@ -8,7 +8,7 @@ indexed: false
 ## Introduction
 
 In this article, you will find examples of the provided resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
-Please read the page covering the **[category API resource](../api-resource-categories)** if you haven't yet, to get more information about the category resource and the data it provides.
+Please read the page covering the **[category API resource](/developers-guide/rest-api/api-resource-categories/)** if you haven't yet, to get more information about the category resource and the data it provides.
 
 These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-a)**.
 

--- a/source/developers-guide/rest-api/examples/customer/index.md
+++ b/source/developers-guide/rest-api/examples/customer/index.md
@@ -8,7 +8,7 @@ indexed: false
 ## Introduction
 
 In this article, you will find examples of the customer resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
-Please read the page covering the **[customer API resource](../api-resource-customer)** if you haven't yet, to get more information about the customer resource and the data it provides.
+Please read the page covering the **[customer API resource](/developers-guide/rest-api/api-resource-customer)** if you haven't yet, to get more information about the customer resource and the data it provides.
 
 These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-a)**.
 

--- a/source/developers-guide/rest-api/examples/order/index.md
+++ b/source/developers-guide/rest-api/examples/order/index.md
@@ -9,7 +9,7 @@ indexed: false
 
 In this article you can read more about using the orders resource.
 The following part will show you examples including provided data and data you need to provide if you want to use this resource.
-Please read **[Orders](../api-resource-orders)** if you did not yet, to get more information about the orders resource and the data it provides.
+Please read **[Orders](/developers-guide/rest-api/api-resource-orders/)** if you did not yet, to get more information about the orders resource and the data it provides.
 Also we are using the API client of the following document **[API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-a)**.
 
 ## Example 1 - Load all orders

--- a/source/developers-guide/rest-api/examples/translation/index.md
+++ b/source/developers-guide/rest-api/examples/translation/index.md
@@ -9,7 +9,7 @@ indexed: false
 
 In this article you can read more about using the translation resource.
 The following part will show you examples including provided data and data you need to provide if you want to use this resource.
-Please read **[Translation](../api-resource-translation)** if you did not yet, to get more information about the orders resource and the data it provides.
+Please read **[Translation](/developers-guide/rest-api/api-resource-translation/)** if you did not yet, to get more information about the translation resource and the data it provides.
 Also we are using the API client of the following document **[API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-a)**.
 
 ## Example 1 - Creating a new translation


### PR DESCRIPTION
This fixes link on pages like https://developers.shopware.com/developers-guide/rest-api/examples/order/
