### PR TITLE
Disable debug mode

### DIFF
--- a/source/assets/js/app.js
+++ b/source/assets/js/app.js
@@ -4,7 +4,7 @@ $(function() {
         apiKey: '4c10d9397401c1dbbbae98ad3897c5e0',
         indexName: 'shopware',
         inputSelector: 'input#search-query',
-        debug: true, // Set debug to true if you want to inspect the dropdown
+        debug: false, // Set debug to true if you want to inspect the dropdown
         algoliaOptions: {
             hitsPerPage: 7
         }


### PR DESCRIPTION
The debug mode was still active which has the effect that the auto complete result will not be closed when the user clicks outside of the pop in.