### PR TITLE
Add automatic controller registration documentation

### DIFF
--- a/source/developers-guide/plugin-system/index.md
+++ b/source/developers-guide/plugin-system/index.md
@@ -389,7 +389,7 @@ class SwagControllerExample extends Plugin
 ### Controller auto-registration
 
 As of version `5.2.7` there is no need for a subscriber which registers your controllers. This will be automatically done by the Shopware core.
-Just place a controller in `SwagControllerExample/Controllers/*` and you are done. 
+Just place a controller in `SwagControllerExample/Controllers/Backend|Frontend|Widgets|Api` and you are done. 
 The registration of the template would be done, i.e. in the `preDispatch()`-Method of your controller.
 
 ```php

--- a/source/developers-guide/plugin-system/index.md
+++ b/source/developers-guide/plugin-system/index.md
@@ -386,6 +386,26 @@ class SwagControllerExample extends Plugin
 }
 ```
 
+### Controller auto-registration
+
+As of version `5.2.7` there is no need for a subscriber which registers your controllers. This will be automatically done by the Shopware core.
+Just place a controller in `SwagControllerExample/Controllers/*` and you are done. 
+The registration of the template would be done, i.e. in the `preDispatch()`-Method of your controller.
+
+```php
+class Shopware_Controllers_Frontend_MyController extends \Enlight_Controller_Action
+{
+    public function preDispatch()
+    {
+        /** @var \Shopware\Components\Plugin $plugin */
+        $plugin = $this->get('kernel')->getPlugins()['SwagControllerExample'];
+        
+        $this->get('template')->addTemplateDir($plugin->getPath() . '/Resources/views/');
+        $this->get('snippets')->addConfigDir($plugin->getPath() . '/Snippets/');
+    }
+}
+```
+
 ## Add console commands
 
 There are two ways to add Shopware [CLI Commands](/developers-guide/shopware-5-cli-commands/).

--- a/source/developers-guide/plugin-system/index.md
+++ b/source/developers-guide/plugin-system/index.md
@@ -388,8 +388,9 @@ class SwagControllerExample extends Plugin
 
 ### Controller auto-registration
 
-As of version `5.2.7` there is no need for a subscriber which registers your controllers. This will be automatically done by the Shopware core.
-Just place a controller in `SwagControllerExample/Controllers/Backend|Frontend|Widgets|Api` and you are done. 
+The auto-registration is available in Shopware 5.2.7 or above.
+To make use of it, create a file like `SwagControllerExample/Controllers/(Backend|Frontend|Widgets|Api)/MyController.php` 
+and follow our controller naming conventions. After that, you'll be able to call `MyController`.
 The registration of the template would be done, i.e. in the `preDispatch()`-Method of your controller.
 
 ```php

--- a/source/developers-guide/plugin-system/index.md
+++ b/source/developers-guide/plugin-system/index.md
@@ -415,11 +415,11 @@ class SwagCommandExample extends Plugin
 
 ### Commands as Services
 
-As of Shopware 5.2.2 you can also register commands as a service and tag it with `console.command`:
+As of Shopware 5.2.2 you can also register commands as a service and tag it with `console.command` in the `Resources/services.xml`:
 
 ```xml
-<!-- Resources/services.xml -->
 <?xml version="1.0" encoding="UTF-8" ?>
+
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
@@ -462,8 +462,9 @@ You can use the CLI to install the plugin with extended error messages: <code>ph
 
 ### Plugin Metadata 
  
+Example `plugin.xml`:
+ 
 ```
-<!-- plugin.xml -->
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.2/engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">Slogan des Tages</label>
@@ -484,11 +485,10 @@ You can use the CLI to install the plugin with extended error messages: <code>ph
 ### Plugin Configuration / Forms
 
 
-Backend plugin configuration can be extended by `config.xml` file. This replaces the usage of `$this->Form()` on old `Shopware_Components_Plugin_Bootstrap`
+Backend plugin configuration can be extended by `Resources/config.xml` file. This replaces the usage of `$this->Form()` on old `Shopware_Components_Plugin_Bootstrap`.
 
 
 ```
-<!-- Resources/config.xml -->
 <?xml version="1.0" encoding="utf-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.2/engine/Shopware/Components/Plugin/schema/config.xsd">
     <elements>
@@ -510,8 +510,9 @@ Shopware()->Config()->getByNamespace('SwagSloganOfTheDay', 'slogan'),
 
 ### Backend Menu Items
 
+Example `Resources/menu.xml`:
+
 ```xml
-<!-- Resources/menu.xml -->
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.2/engine/Shopware/Components/Plugin/schema/menu.xsd">
 	<entries>
@@ -576,4 +577,4 @@ SwagSloganOfTheDay.zip
 
 - <a href="https://github.com/shyim/shopware-profiler">github.com/shyim/shopware-profiler</a>
 - <a href="https://github.com/bcremer/SwagModelTest">github.com/bcremer/SwagModelTest</a>
-
+- <a href="https://github.com/shopwareLabs/SwagBackendOrder">github.com/shopwareLabs/SwagBackendOrder</a>


### PR DESCRIPTION
Shopware `> 5.2.7` automatically registers controllers, I think it should be documented :)

Further I removed invalid XML-comments which lead to copy-paste errors and added another example plugin.
