### PR TITLE
remove obsolete deleting of cache

### DIFF
--- a/source/developers-guide/attribute-system/index.md
+++ b/source/developers-guide/attribute-system/index.md
@@ -202,8 +202,6 @@ class SwagAttribute extends Plugin
 Sometimes it's necessary to rebuild the attribute models after attribute creation, update or deletion.
 
 ```
-$metaDataCache = Shopware()->Models()->getConfiguration()->getMetadataCacheImpl();
-$metaDataCache->deleteAll();
 Shopware()->Models()->generateAttributeModels(['s_articles_attributes']);
 ```
 


### PR DESCRIPTION
I don't think it is necessary to clear the cache on your own.
if you call `generateAttributeModels()`, the `regenerateAttributeProxies()` [(method)](https://github.com/shopware/shopware/blob/5.2/engine/Shopware/Components/Model/ModelManager.php#L255) is also called which does the same

/cc @bcremer @wolv-dev 