### PR TITLE
Fix wrong getter method for the filter event return

### DIFF
--- a/source/developers-guide/event-guide/index.md
+++ b/source/developers-guide/event-guide/index.md
@@ -194,7 +194,7 @@ to modify this list and return a modified set with your subscriber:
 public function myEventSubscriber(\Enlight_Event_EventArgs $args)
 {
     $amount = $args->get('categoryId'); 
-    $result = $args->get('return');
+    $result = $args->getReturn();
     
     $result[] = 'sw-abc';
     


### PR DESCRIPTION
Since `\Enlight_Event_EventArgs::get('return');` would return the wrong variable (in most cases `null`). 
See https://github.com/shopware/shopware/blob/5.2/engine/Library/Enlight/Event/EventArgs.php#L129 vs https://github.com/shopware/shopware/blob/5.2/engine/Library/Enlight/Collection/ArrayCollection.php#L85