### PR TITLE
Improve error handling of example API client

### DIFF
--- a/source/developers-guide/rest-api/index.md
+++ b/source/developers-guide/rest-api/index.md
@@ -153,7 +153,7 @@ class ApiClient
         if (!$decodedResult['success']) {
             echo '<h2>No Success</h2>';
             echo '<p>' . $decodedResult['message'] . '</p>';
-            if ($decodedResult['errors'] && is_array($decodedResult['errors'])) {
+            if (array_key_exists('errors', $decodedResult) && is_array($decodedResult['errors'])) {
                 echo '<p>' . join('</p><p>', $decodedResult['errors']) . '</p>';
             }
 


### PR DESCRIPTION
Fixes a warning when the key 'errors' does not exist in the array $decodedResult