### PR TITLE
Add semicolon to example

### DIFF
--- a/source/designers-guide/javascript-coding-style/index.md
+++ b/source/designers-guide/javascript-coding-style/index.md
@@ -138,7 +138,7 @@ var list = [1, 2, 3, 4];
 function greet (name, options) { ... }
 
 // ✗ avoid 
-var list = [1,2,3,4]
+var list = [1,2,3,4];
 function greet (name,options) { ... }
 ```
 


### PR DESCRIPTION
Example for "comma spacing" lacked a semicolon. Added it.