### PR TITLE
Improve config settings of elasticsearch

### DIFF
--- a/source/sysadmins-guide/elasticsearch-setup/index.md
+++ b/source/sysadmins-guide/elasticsearch-setup/index.md
@@ -47,7 +47,7 @@ By default, Elasticsearch integration is disabled in Shopware, as most shops won
 To enable Elasticsearch (provided it's already installed, configured and running), edit your `config.php` file, adding the following array:
 
 ```
-[
+...
     'es' => [
         'enabled' => true,
         'number_of_replicas' => null,
@@ -59,8 +59,35 @@ To enable Elasticsearch (provided it's already installed, configured and running
         ]
     ],
     // Other configuration settings...
-]
+...
 ```
+
+Your config.php should look like this now:
+
+```
+<?php
+return [
+    'db' => [
+        'username' => 'dbuser',
+        'password' => 'dbpw,
+        'dbname' => 'dbname',
+        'host' => 'localhost',
+        'port' => '3306',  
+],
+    'es' => [
+        'enabled' => true,
+        'number_of_replicas' => null,
+        'number_of_shards' => null,
+        'client' => [
+            'hosts' => [
+                'localhost:9200'
+            ]
+        ]
+    ],
+
+];
+```
+
 
 Shopware 5 communicates with Elasticsearch using the latter's REST API. The `hosts` array accepts multiple address syntaxes, about which you can read more [here](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_configuration.html#_host_configuration). The `number_of_shards` and `number_of_replicas` parameter provided to the generated index. A `null` configuration allows to use the elastic search server configuration of this parameters.
 


### PR DESCRIPTION
when you copy&paste it to your existing config.php, the first array cling square causes problems and the settings will not be used. the view should be better with an example config.php