### PR TITLE
Fix broken link to customer streams api

### DIFF
--- a/source/developers-guide/customer-streams-extension/index.md
+++ b/source/developers-guide/customer-streams-extension/index.md
@@ -351,4 +351,4 @@ You download the example plugin above
 
 ## REST API
 We also offer a complete REST API for Customer Streams.
-For a detailed documentation click **[here](https://developers.shopware.com/developers-guide/rest-api/customer-streams/)**.
+For a detailed documentation click **[here]({{ site.url }}/developers-guide/rest-api/customer-streams/)**.

--- a/source/developers-guide/customer-streams-extension/index.md
+++ b/source/developers-guide/customer-streams-extension/index.md
@@ -351,4 +351,4 @@ You download the example plugin above
 
 ## REST API
 We also offer a complete REST API for Customer Streams.
-For a detailed documentation click **[here](developers-guide/rest-api/customer-streams/)**.
+For a detailed documentation click **[here](https://developers.shopware.com/developers-guide/rest-api/customer-streams/)**.


### PR DESCRIPTION
Link is broken and results in 404, set direct link to correct page.