### PR TITLE
Added missing model for Order resource (Payment)

### DIFF
--- a/source/developers-guide/rest-api/models/index.md
+++ b/source/developers-guide/rest-api/models/index.md
@@ -564,8 +564,8 @@ subgroup: REST API
 
 ## Payment
 
-* **Model:** Shopware\Models\Customer\Payment
-* **Table:** s_core_payment
+* **Model:** Shopware\Models\Payment\Payment
+* **Table:** s_core_paymentmeans
 
 ### Structure
 

--- a/source/developers-guide/rest-api/models/index.md
+++ b/source/developers-guide/rest-api/models/index.md
@@ -562,6 +562,30 @@ subgroup: REST API
 | group                    | string                  |                                                 |
 | sendMail              | boolean                  |                                                 |
 
+## Payment
+
+* **Model:** Shopware\Models\Customer\Payment
+* **Table:** s_core_payment
+
+### Structure
+
+| Field               | Type                  | Original object                                 |
+|---------------------|-----------------------|-------------------------------------------------|
+| id                    | integer (primary key) |                                                 |
+| name          | string |                                                 |
+| description      | string                  |                                                    |
+| template              | string                  |                                                    |
+| hide                  | boolean                  |                                                    |
+| additionalDescription                  | string                  |                                                    |
+| debitPercent          | float                  |                                                    |
+| surcharge              | integer                  |                                                    |
+| surchargeString          | string                  |                                                    |
+| position              | integer              |                                                    |
+| active              | boolean              |                                                    |
+| esdActive              | boolean              |                                                    |
+| mobileInactive              | boolean              |                                                    |
+| pluginId              | integer              |                                                    |
+
 ## Payment Data
 
 * **Model:** Shopware\Models\Customer\PaymentData


### PR DESCRIPTION
When getting a specific Order, you also get a Payment-model.
This model was missing, so I added it ;).