### PR TITLE
Fix variable case in naming

### DIFF
--- a/source/developers-guide/global-variables-in-templates/index.md
+++ b/source/developers-guide/global-variables-in-templates/index.md
@@ -40,7 +40,7 @@ Our example will just add the user login status to the template.
  */
 public function onPostDispatch(\Enlight_Controller_ActionEventArgs $args)
 {
-    $args->getSubject()->View()->assign('sUserloggedIn', Shopware()->Modules()->Admin()->sCheckUser());
+    $args->getSubject()->View()->assign('sUserLoggedIn', Shopware()->Modules()->Admin()->sCheckUser());
 }
 ```
 


### PR DESCRIPTION
Rename variable in order to prevent confusion due to inconsistent naming:
`sUserLoggedIn` misleadingly spelled `sUserloggedIn`.