### PR TITLE
SW-19708 - Add warning for REST API docs

### DIFF
--- a/source/developers-guide/rest-api/api-resource-address/index.md
+++ b/source/developers-guide/rest-api/api-resource-address/index.md
@@ -109,6 +109,13 @@ Appended to the above mentioned list, you will also find the following data:
 | attribute                | array                 |                                                      |
 
 
+## PUT (update)
+
+<div class="alert alert-warning">
+<strong>Note:</strong> Changing a customer id on addresses is not supported, you can leave the customer id out of the
+request, or just set the same customer id which owns the address.
+</div>
+
 ## DELETE
 To delete an address, simply call the specified resource with the `DELETE` operation as the following example shows:
 

--- a/watch.sh
+++ b/watch.sh
@@ -3,7 +3,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-rm -rv ./output_*
+rm -rf ./output_*
 
 sculpinBin="./vendor/bin/sculpin"
 


### PR DESCRIPTION
The warning is regarding when an API user tries to assign address to another customer