### PR TITLE
[REST-API] Fixed GET schema for category

### DIFF
--- a/source/developers-guide/rest-api/api-resource-categories/index.md
+++ b/source/developers-guide/rest-api/api-resource-categories/index.md
@@ -53,7 +53,7 @@ Single category details can be retrieved via the category ID:
 | blog                | boolean               |                                                                               |
 | path                | string                |                                                                               |
 | showFilterGroups    | boolean               |                                                                               |
-| external            | boolean               |                                                                               |
+| external            | string                |                                                                               |
 | hideFilter          | boolean               |                                                                               |
 | hideTop             | boolean               |                                                                               |
 | changed             | DateTime              |                                                                               |


### PR DESCRIPTION
Fixed schema for GET operation. The parameter 'external' is a string instead of a boolean.