### PR TITLE
[REST-API] Fixed field for Billing model

### DIFF
--- a/source/developers-guide/rest-api/models/index.md
+++ b/source/developers-guide/rest-api/models/index.md
@@ -133,7 +133,7 @@ subgroup: REST API
 |---------------------|-----------------------|-------------------------------------------------|
 | id                    | integer (primary key) |                                                 |
 | customerId             | integer (foreign key) |                                                 |
-| countryId             | integer (foreign key) | **[Country](#country)**                         |
+| country             | object | **[Country](#country)**                         |
 | stateId             | integer (foreign key) |                                                 |
 | company              | string                  |                                                    |
 | department          | string                  |                                                    |


### PR DESCRIPTION
Billing does require a country object instead of just a countryId.