### PR TITLE
Fix-missing-redisAuth-parameter

### DIFF
--- a/source/developers-guide/shopware-config/index.md
+++ b/source/developers-guide/shopware-config/index.md
@@ -203,7 +203,8 @@ With Shopware 5.3 it is possible to use [redis](https://redis.io/) as cache adap
             array(
                 'host' => '127.0.0.1',
                 'port' => 6379,
-                'dbindex' => 0
+                'dbindex' => 0,
+                'redisAuth' => ''
             ),
         ),
     ],


### PR DESCRIPTION
Since SW-20299 it is possible to use a redis-auth, but if this parameter isn't set, the implementation won't work.