### PR TITLE
fix syntax

### DIFF
--- a/source/developers-guide/shopware-5-plugin-update-guide/index.md
+++ b/source/developers-guide/shopware-5-plugin-update-guide/index.md
@@ -436,7 +436,7 @@ $.plugin('yourName', {
    init: function() {
        // ...initialization code
 
-       //The applyDataAttributes function merges data attributes into plugin options. Example element: <div class="test" data-exampleValue="value2"></div>
+       //The applyDataAttributes function merges data attributes into plugin options. Example element: <div class="test" data-example-value="value2"></div>
        //The default "exampleValue" variable will be overwritten with "value2".
        //This value is then available in this.opts.exampleValue variable
 


### PR DESCRIPTION
Attribute names will be parsed vom snake case (html) to camel case (js).