### PR TITLE
Fixed debug usage

### DIFF
--- a/source/developers-guide/debugging/index.md
+++ b/source/developers-guide/debugging/index.md
@@ -122,7 +122,7 @@ exit();
 Instead, you should use the Doctrine debug helper to print / log complex objects: 
 
 ```
-$result = \Doctrine\Common\Util\Debug::dump(Shopware()->Shop())
+$result = \Doctrine\Common\Util\Debug::dump(Shopware()->Shop(), 2, true, false)
 // now safely log $result with your preferred logger
 ```
 


### PR DESCRIPTION
The fourth argument must be false, so dump returns the result