### PR TITLE
Fixed style tile link

### DIFF
--- a/source/designers-guide/index.html
+++ b/source/designers-guide/index.html
@@ -62,27 +62,27 @@ menu_style: bullet
 
         <div class="styletile-headline center">
             <h3>Shopware style tile</h3>
-            <p>Your guide for the Shopware Responsive Theme<a href="http://styletile.dev.shopware.in/" target="_blank"> - learn more.</a></p>
+            <p>Your guide for the Shopware Responsive Theme<a href="/styletile/" target="_blank"> - learn more.</a></p>
         </div>
 
         <div class="row">
 
             <div class="col small">
-                <a href="http://styletile.dev.shopware.in/" target="_blank"><div class="styletile--screenshot"></div></a>
+                <a href="/styletile/" target="_blank"><div class="styletile--screenshot"></div></a>
             </div>
 
             <div class="col medium">
                 <div class="styletile--dialog">
-                    <a href="http://styletile.dev.shopware.in/" target="_blank"><div class="avatar-one"></div></a>
+                    <a href="/styletile/" target="_blank"><div class="avatar-one"></div></a>
                     <div class="chat"><h4>Preview</h4>Get a quick and visual overview of every component that Shopware introduces.</div>
                 </div>
                 <div class="styletile--dialog">
-                    <a href="http://styletile.dev.shopware.in/" target="_blank"><div class="avatar-two"></div></a>
+                    <a href="/styletile/" target="_blank"><div class="avatar-two"></div></a>
                     <div class="chat"><h4>Cheatsheet</h4>View all the regular classes and variables that Shopware introduces on one page.</div>
                 </div>
             </div>
 
-            <div class="button"><a href="http://styletile.dev.shopware.in/" target="_blank">View now</a></div>
+            <div class="button"><a href="/styletile/" target="_blank">View now</a></div>
 
         </div>
 


### PR DESCRIPTION
Links to style tile now lead to `/styletile/` instead of `http://styletile.dev.shopware.in/`