### PR TITLE
Linked order to the dedicated order page

### DIFF
--- a/source/developers-guide/rest-api/models/index.md
+++ b/source/developers-guide/rest-api/models/index.md
@@ -416,7 +416,7 @@ subgroup: REST API
 | date                 | date/time              |                                                 |
 | typeId              | integer (foreign key) | **[DocumentType](#document-type)**                |
 | customerId          | integer (foreign key) | **[Customer](#customer)**                        |
-| orderId              |    integer (foreign key) | **[Order](#order)**                                |
+| orderId              |    integer (foreign key) | **[Order](../api-resource-orders/)**                                |
 | amount              | double                  |                                                 |
 | documentId          | integer (foreign key) |                                                 |
 | hash                  | string                   |                                                    |


### PR DESCRIPTION
Like article there is no model summary on this page but a dedicated page. Order has no summary on this page either but is linked as one.