### PR TITLE
Updated the shopware_version

### DIFF
--- a/source/developers-guide/custom-shopping-world-elements/index.md
+++ b/source/developers-guide/custom-shopping-world-elements/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Custom shopping world elements
 github_link: developers-guide/custom-shopping-world-elements/index.md
-shopware_version: 5.2.0
+shopware_version: 5.2.10
 indexed: true
 tags:
   - shopping worlds


### PR DESCRIPTION
Updated the shopware_version to 5.2.10 because the service "shopware.emotion_component_installer" was first implemented in this version and it was mentioned in the "Registering a new element" section.