### PR TITLE
Fixed typo in postMessageApi example

### DIFF
--- a/source/developers-guide/lightweight-backend-modules-api/index.md
+++ b/source/developers-guide/lightweight-backend-modules-api/index.md
@@ -128,7 +128,7 @@ Sends a message to a subwindow
 **Example**:
 ```js
 postMessageApi.sendMessageToSubWindow({
-    name: 'customSubWindow',
+    component: 'customSubWindow',
     params: {
         msg: 'Your message',
         foo: [ 'bar', 'batz' ]


### PR DESCRIPTION
The property name is 'component' not 'name'. It's not working with the key 'name'.
'component' is also used in the official example: https://github.com/shopwareLabs/SwagLightweightModule/blob/fdee4babccd35db0dc1ce995a011e332ad546675/Resources/views/backend/_base/layout.tpl#L140