### PR TITLE
Add marketing tag removal to varnish vcl config

### DIFF
--- a/source/sysadmins-guide/varnish-setup/index.md
+++ b/source/sysadmins-guide/varnish-setup/index.md
@@ -150,6 +150,13 @@ sub vcl_recv {
     # Mitigate httpoxy application vulnerability, see: https://httpoxy.org/
     unset req.http.Proxy;
 
+    # Strip query strings only needed by browser javascript
+    if (req.url ~ "(\?|&)(gclid|utm_[a-z]+)=") {
+        # see rfc3986#section-2.3 "Unreserved Characters" for regex
+        set req.url = regsuball(req.url, "(gclid|utm_[a-z]+)=[A-Za-z0-9\-\_\.\~]+&?", "");
+    }
+    set req.url = regsub(req.url, "(\?|\?&|&)$", "");
+
     # Normalize query arguments
     set req.url = std.querysort(req.url);
 

--- a/source/sysadmins-guide/varnish-setup/index.md
+++ b/source/sysadmins-guide/varnish-setup/index.md
@@ -150,10 +150,10 @@ sub vcl_recv {
     # Mitigate httpoxy application vulnerability, see: https://httpoxy.org/
     unset req.http.Proxy;
 
-    # Strip query strings only needed by browser javascript
-    if (req.url ~ "(\?|&)(gclid|utm_[a-z]+)=") {
+    # Strip query strings only needed by browser javascript. Customize to used tags.
+    if (req.url ~ "(\?|&)(pk_campaign|piwik_campaign|pk_kwd|piwik_kwd|pk_keyword|pixelId|kwid|kw|adid|chl|dv|nk|pa|camid|adgid|cx|ie|cof|siteurl|utm_[a-z]+|_ga|gclid)=") {
         # see rfc3986#section-2.3 "Unreserved Characters" for regex
-        set req.url = regsuball(req.url, "(gclid|utm_[a-z]+)=[A-Za-z0-9\-\_\.\~]+&?", "");
+        set req.url = regsuball(req.url, "(pk_campaign|piwik_campaign|pk_kwd|piwik_kwd|pk_keyword|pixelId|kwid|kw|adid|chl|dv|nk|pa|camid|adgid|cx|ie|cof|siteurl|utm_[a-z]+|_ga|gclid)=[A-Za-z0-9\-\_\.\~]+&?", "");
     }
     set req.url = regsub(req.url, "(\?|\?&|&)$", "");
 


### PR DESCRIPTION
this is similar to Shopwares `ignored_url_parameters`, then inspired by PR [#1159](https://github.com/shopware/shopware/pull/1195) and introduced in [SW-19263](https://github.com/shopware/shopware/commit/fae510cd5d50d0bb0d5dad4ed5daf9bd5fa5b345) to improve the cache hit rate. It uses a minimal set of tags and is intended to provide a stub for varnish users to check their own backend request logs and a place in the vcl to insert them. The second regex matches leftover trailing "?" and/or "&" symbols