### PR TITLE
Change config to support more Shopware versions

### DIFF
--- a/source/developers-guide/shopware-5-media-service/index.md
+++ b/source/developers-guide/shopware-5-media-service/index.md
@@ -194,10 +194,10 @@ You should add the following options to your `config.php`. Please notice the `st
 ```php
 'cdn' => [
     'adapters' => [
+        'strategy' => 'plain',
         'local' => [
             'type' => 'local',
             'mediaUrl' => '',
-            'strategy' => 'plain',
             'path' => realpath(__DIR__ . '/'),
             'permissions' => [
                 'file' => [


### PR DESCRIPTION
Seid 5.5 funktioniert die Config nicht mehr wie bisher beschrieben. Durch diese Änderung kann das Problem behoben werden, scheint auch mit älteren Shopware-Versionen zu funktionieren