### PR TITLE
Fix value of unitize mixin property

### DIFF
--- a/source/designers-guide/custom-listing-page/index.md
+++ b/source/designers-guide/custom-listing-page/index.md
@@ -258,7 +258,7 @@ In the last step we will add styling to the product box itself, add the hover ef
         width: 100%;
     
         .info--name {
-            .unitize(font-size, 30px);
+            .unitize(font-size, 30);
             color: #000;
             display: block;
             font-weight: 300;
@@ -266,7 +266,7 @@ In the last step we will add styling to the product box itself, add the hover ef
         }
     
         .info--price {
-            .unitize(font-size, 22px);
+            .unitize(font-size, 22);
             display: block;
             text-align: center;
         }
@@ -278,7 +278,7 @@ In the last step we will add styling to the product box itself, add the hover ef
         transform: translate(0, -50%);
     
         .image--media img {
-            .unitize(padding, 30px);
+            .unitize(padding, 30);
             height: 100%;
         }
     }


### PR DESCRIPTION
Property-value relationship in unitze mixin is defined as `@{property}: ~"@{pxValue}px"`. So the `px` ending in mixin causes  an invalid value.