### PR TITLE
Varnish config: Pass checkout and account paths directly to php

### DIFF
--- a/source/sysadmins-guide/varnish-setup/index.md
+++ b/source/sysadmins-guide/varnish-setup/index.md
@@ -243,6 +243,7 @@ sub vcl_recv {
     }
 
     # Always pass these paths directly to php without caching
+    # Note: virtual URLs might bypass this rule (e.g. /en/checkout)
     if (req.url ~ "^/(checkout|account|backend)(/.*)?$") {
         return (pass);
     }

--- a/source/sysadmins-guide/varnish-setup/index.md
+++ b/source/sysadmins-guide/varnish-setup/index.md
@@ -242,10 +242,8 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Do not cache these paths.
-    if (req.url ~ "^/backend" ||
-        req.url ~ "^/backend/.*$") {
-
+    # Always pass these paths directly to php without caching
+    if (req.url ~ "^/(checkout|account|backend)(/.*)?$") {
         return (pass);
     }
 


### PR DESCRIPTION
# Summary
This pull request updates the Varnish configuration, so that the /checkout and /account endpoints are passed through varnish without caching. This change allows multiple requests to these endpoints to run in parallel.

# Background
Varnish makes sure that only one request per URL is in flight for backend fetches. This allows to answer all requests to one URL as soon as the first request is successful. But this only works if the request can be cached. For URLs that can not be cached it limits the requests to each unique URL to one in flight request. By passing varnish for these URLs, more than one request can run in parallel to these endpoints.


