### PR TITLE
Removed margin-top from .code-collapsed

### DIFF
--- a/source/assets/css/_imports/codeExpand.less
+++ b/source/assets/css/_imports/codeExpand.less
@@ -58,6 +58,5 @@ pre code {
 .code-collapsed {
     height: 370px;
     overflow: hidden;
-    margin-top: 30px;
     margin-bottom: 60px;
 }


### PR DESCRIPTION
Only on collapsed code there is a margin on top resulting in ugly jumping of code block.