### PR TITLE
Added reference to existing datepicker documentation

### DIFF
--- a/components.html
+++ b/components.html
@@ -513,11 +513,18 @@
                         <p>
                             The datepicker is a calendar overlay tool that simplyfies the selection of dates for input elements. It creates a calendar widget that simplifies the selection of dates for date input elements.
                             The styling includes the state styles, the styling with multiple calendars and the rtl-support.
-                            (Is based on the JQuery UI Datepicker Element)
+                            (Is based on the JQuery UI Datepicker Element).
+                            
+                            See the <a href="/designers-guide/datepicker/">designers guide</a> for previews and configuration examples.
                         </p>
                         <div class="spacer">
                             <a href="http://jqueryui.com/datepicker/" target="_blank" class="btn is--secondary rounded-3">JQuery UI Documentation</a>
                         </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-12 example complete">
+                        <pre><code class="html on--white">&#x3C;input type=&#x22;datetime&#x22; data-datepicker=&#x22;true&#x22;&#x3E;</code></pre>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
It was weird to neither have a preview nor a code example. The reference to the jquery ui page said: `$('input').datepicker();` which was not working in shopware and is therfore confusing. As the current js files in styletile do not contain the datepicker I did not include a preview iframe but referenced the documention for an approach that is a bit more clear.