### PR TITLE
Fix wrong filter description in rest api

### DIFF
--- a/source/developers-guide/rest-api/api-resource-article/index.md
+++ b/source/developers-guide/rest-api/api-resource-article/index.md
@@ -40,20 +40,20 @@ This API call requires one of the following parameters to be defined:
 
 #### Optional Parameters
 Optional parameters can be provided:
-* language `id` or `locale` (from `s_core_locales`). If used, the returned info will be provided in the specified language (if available)
+* language `id` or `shop` (from `s_core_shops`). If used, the returned info will be provided in the specified language (if available)
 * `considerTaxInput`: By default, all returned prices are net values. If the boolean `considerTaxInput` is set to true, gross values will be returned instead.
 
 | Identifier       | Parameter | DB column              | Example call                             |
 |------------------|-----------|------------------------|------------------------------------------|
-| language         | id        | s_core_locales         | /api/articles/2?language=de_DE           |
+| language         | id        | s_core_shops           | /api/articles/2?language=3               |
 | considerTaxInput | boolean   |                        | /api/articles/2?considerTaxInput=true    |
 
 You can use one or more of these parameters together.
 
 Here is an example of a parametrized URL:
 
-* **http://my-shop-url/api/articles/2?considerTaxInput=true&language=de_DE**
-* **http://my-shop-url/api/articles/SW10003?useNumberAsId=true&considerTaxInput=true&language=de_DE**
+* **http://my-shop-url/api/articles/2?considerTaxInput=true&language=3**
+* **http://my-shop-url/api/articles/SW10003?useNumberAsId=true&considerTaxInput=true&language=3**
 
 #### Return value
 


### PR DESCRIPTION
See: https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Components/Api/Resource/Article.php#L221-L226

The filter ?language uses the shopID, not a locale. Since translation of entities are based on the shop, not a locale, it won't make any sence to use the locale here. Further the locale is not a unique alias, since more than one shop can have the locale en_GB.