### PR TITLE
Added missing first line to build the javascript correctly

### DIFF
--- a/source/developers-guide/plugin-lastregistrations-widget/index.md
+++ b/source/developers-guide/plugin-lastregistrations-widget/index.md
@@ -305,6 +305,7 @@ The rest should be self explanatory. For more help take a look at the __ExtJS do
 
 ### Resources/views/backend/index/swag_last_registrations/store/account.js
 ```
+//
 Ext.define('Shopware.apps.Index.swagLastRegistrationsWidget.store.Account', {
     /**
      * Extends the default Ext Store
@@ -333,6 +334,7 @@ Ext.define('Shopware.apps.Index.swagLastRegistrationsWidget.store.Account', {
 
 ### Resources/views/backend/index/swag_last_registrations/model/account.js
 ```
+//
 Ext.define('Shopware.apps.Index.swagLastRegistrationsWidget.model.Account', {
 
     extend: 'Ext.data.Model',


### PR DESCRIPTION
As this seems to be a :clipboard: :ramen: guide the files should contain out of the box correct content to make it easier to get started with ext js. The first line in the included files should be added with useless statements or smarty statements as in the compiled main.js this line is commented out.
If this first line is missing invalid javascript is generated.