### PR TITLE
Added hint to add snippets

### DIFF
--- a/source/developers-guide/plugin-lastregistrations-widget/index.md
+++ b/source/developers-guide/plugin-lastregistrations-widget/index.md
@@ -97,7 +97,7 @@ is called. In the app.js we add our own stores, models etc.
     }
  ```
  The __install()__ method creates a new widget Entity and adds it to our plugin. It is important to set the same
- __name__ as in our view alias(`Resources/views/backend/index/swag_last_registrations/view/main.js`)
+ __name__ as in our view alias(`Resources/views/backend/index/swag_last_registrations/view/main.js`) as well as adding a snippet for this __name__ under `Resources/snippets/backend/widget/labels.ini`.
 
 `uninstall()`
 ```


### PR DESCRIPTION
The guide is quite detailed. The demand on snippets for the extjs view and their namespaces can be extrapolated by reading the code of the extjs view. But there is no hint to add a snippet to the widget labels to display correctly in the "widget add" dropdown.