### PR TITLE
Added payment status

### DIFF
--- a/source/developers-guide/rest-api/models/index.md
+++ b/source/developers-guide/rest-api/models/index.md
@@ -636,7 +636,7 @@ The field `path` has to be the local path to the image, seen from the root of th
 | Field               | Type                  | Original object                                 |
 |---------------------|-----------------------|-------------------------------------------------|
 | id                    | integer (primary key) |                                                 |
-| description            | string                  |                                                 |
+| name            | string                  |                                                 |
 | position              | integer                  |                                                 |
 | group                    | string                  |                                                 |
 | sendMail              | boolean                  |                                                 |
@@ -708,6 +708,21 @@ The field `path` has to be the local path to the image, seen from the root of th
 | iban                  | string                  |                                                 |
 | amount              | string                  |                                                 |
 | createdAt              | date/time              |                                                 |
+
+## Payment Status
+
+* **Model:** Shopware\Models\Order\Status
+* **Table:** s_core_states
+
+### Structure
+
+| Field               | Type                  | Original object                                 |
+|---------------------|-----------------------|-------------------------------------------------|
+| id                    | integer (primary key) |                                                 |
+| name            | string                  |                                                 |
+| position              | integer                  |                                                 |
+| group                    | string                  |                                                 |
+| sendMail              | boolean                  |                                                 |
 
 ## Price
 


### PR DESCRIPTION
The payment status link on https://developers.shopware.com/developers-guide/rest-api/api-resource-orders/ leads to nothing so i added the payment status model.
I also fixed the column "description" to "name" as this is the naming in the api result.