### PR TITLE
Rewrite API examples to JSON, add badges to represent the HTTP request method

### DIFF
--- a/source/_partials/api_badge.twig
+++ b/source/_partials/api_badge.twig
@@ -1,0 +1,8 @@
+<div class="api-badge api-badge-{{ method|lower }} {% if body %}body{% endif %}">
+  <span class="method">
+    {{ method }}
+  </span>
+  <span class="route">
+    {{ route|raw }}
+  </span>
+</div>

--- a/source/assets/css/_imports/api-badge.less
+++ b/source/assets/css/_imports/api-badge.less
@@ -1,0 +1,97 @@
+.api-badge {
+
+    display: flex;
+    width: 100%;
+    box-sizing: border-box;
+
+    & + pre, & + .code-wrapper pre {
+        margin-top: 0;
+
+        code.hljs {
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
+        }
+    }
+
+    & + p {
+        margin-top: 1rem;
+    }
+
+    .method, .route {
+        display: block;
+        padding: .25rem .5rem;
+        box-sizing: border-box;
+    }
+
+    .method {
+        color: #fff;
+        font-weight: bold;
+        border-radius: 5px 0 0 5px;
+    }
+
+    .route {
+        width: 100%;
+        color: @text-color;
+        border-radius: 0 5px 5px 0;
+    }
+
+    &.body {
+        .method {
+            border-radius: 5px 0 0 0;
+        }
+
+        .route {
+            border-radius: 0 5px 0 0;
+        }
+
+        .route::after {
+            content: 'request-body attached';
+            display: inline-block;
+            position: relative;
+            float: right;
+            font-size: .8rem;
+            line-height: 1.5rem;
+            color: rgba(0, 0, 0, .2);
+        }
+    }
+
+    &-get {
+        .method {
+            background-color: @highlight-color-blue;
+        }
+
+        .route {
+            background-color: lighten(@highlight-color-blue, 40%);
+        }
+    }
+
+    &-post {
+        .method {
+            background-color: @highlight-color-green;
+        }
+
+        .route {
+            background-color: lighten(@highlight-color-green, 30%);
+        }
+    }
+
+    &-put {
+        .method {
+            background-color: @highlight-color-yellow;
+        }
+
+        .route {
+            background-color: lighten(@highlight-color-yellow, 30%);
+        }
+    }
+
+    &-delete {
+        .method {
+            background-color: @highlight-color-red;
+        }
+
+        .route {
+            background-color: lighten(@highlight-color-red, 40%);
+        }
+    }
+}

--- a/source/assets/css/basic.less
+++ b/source/assets/css/basic.less
@@ -21,6 +21,7 @@
 @import "_imports/start.less";
 @import "_imports/dev-guide.less";
 @import "_imports/des-guide.less";
+@import "_imports/api-badge.less";
 
 /**
  * — Minor Section Heading —
@@ -1616,5 +1617,3 @@ h2#recent-blog-posts a {
         left: 1230px;
     }
 }
-
-

--- a/source/developers-guide/plugin-guidelines/index.md
+++ b/source/developers-guide/plugin-guidelines/index.md
@@ -16,7 +16,7 @@ subgroup: Developing plugins
 There are some issues we come across frequently, when reviewing plugins for the
 community store. This document is intended to help plugin developers implement
 plugins according to
-[our quality guidelines](https://docs.shopware.com/de/plugin-standard-community-store).
+[our quality guidelines](https://docs.shopware.com/en/plugin-standard-for-community-store).
 We hope the examples provided here will be helpful, please feel free to submit
 corrections and suggestions to our
 [devdocs repository](https://github.com/shopware/devdocs/)

--- a/source/developers-guide/rest-api/api-resource-cache/index.md
+++ b/source/developers-guide/rest-api/api-resource-cache/index.md
@@ -84,13 +84,18 @@ To delete all caches, simply call
 * **(DELETE) http://my-shop-url/api/caches**
 
 without providing a cache id. You can also supply a list of caches to be deleted.
-```php
-$restClient->delete(
-    'caches',
-    array(
-        array('id' => 'opcache'),
-        array('id' => 'config'),
-        array('id' => 'http')
-    )
-);
+
+{% include 'api_badge.twig' with {'route': '/api/caches', 'method': 'DELETE', 'body': true} %}
+```json
+[
+    {
+        "id": "opcache"
+    },
+    {
+        "id": "config"
+    },
+    {
+        "id": "http"
+    }
+]
 ```

--- a/source/developers-guide/rest-api/api-resource-user/index.md
+++ b/source/developers-guide/rest-api/api-resource-user/index.md
@@ -27,9 +27,6 @@ For each scenario, we provide an example of the data
 which is required, as well as an exemplary response.
 Please read the page covering the **[REST API Basics](/developers-guide/rest-api/)** if you haven't yet.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
-
 ## Get a list of users
 If you want to get multiple user at once, you can call the /users endpoint.
 
@@ -43,18 +40,23 @@ If you want to get multiple user at once, you can call the /users endpoint.
 
 
 *Example code:*
-```php
-$client->get('users', [
-    'limit' => 10, // limit the number of users to 10
-    'start' => 1, // skip the first one
-    'sort' => [
-        ['property' => 'username', 'direction' => 'DESC']
+
+{% include 'api_badge.twig' with {'route': '/api/users', 'method': 'GET', 'body': true} %}
+```json
+{
+    "limit": 10,
+    "start": 1,
+    "sort": [
+        {
+            "property": "username",
+            "direction": "DESC"
+        }
     ]
-    
-]);
+}
 ```
 
 *Example output:*
+
 ```json
 {
     "total": 2,
@@ -102,17 +104,17 @@ $client->get('users', [
 
 Attention: The properties apiKey, sessionId and password are missing,
 if the API user neither has the update nor the create privilege.
-+
+
 ## Get one user
 If you want to get detailed information about a specific user,
 you can call /users/{userId}
 
-
 *Example code:*
-```php
-$client->get('users/2', []);
-```
+
+{% include 'api_badge.twig' with {'route': '/api/users/2', 'method': 'GET'} %}
+
 *Example output:*
+
 ```json
 {
     "data": {
@@ -143,13 +145,16 @@ If you want to update a user, you can send a PUT request to /users/{userId}
 
 
 *Example code:*
-```php
-$client->put('users/2', [
-    'username' => 'test2'
-]);
+
+{% include 'api_badge.twig' with {'route': '/api/users/2', 'method': 'PUT', 'body': true} %}
+```json
+{
+  "username": "test2"
+}
 ```
 
 *Example output:*
+
 ```json
 {
     "success": true,
@@ -163,25 +168,27 @@ $client->put('users/2', [
 ## Create a new user
 If you want to create a user, you can send a POST request to /users/
 
-
 *Example code:*
-```php
-$client->post('users', [
-    'roleId' => 1,
-    'localeId' => 1,
-    'username' => 'example',
-    'name' => 'test',
-    'email' => 'test@example.org',
-    'active' => 1,
-    'extendedEditor' =>  false,
-    'disabledCache' => false
-]);
+
+{% include 'api_badge.twig' with {'route': '/api/users', 'method': 'POST', 'body': true} %}
+```json
+{
+    "roleId": 1,
+    "localeId": 1,
+    "username": "example",
+    "name": "test",
+    "email": "test@example.org",
+    "active": 1,
+    "extendedEditor": false,
+    "disabledCache": false
+}
 ```
 
 Note: If you do not pass a password, the API will generate a
 secure password and send it in the response.
 
 *Example output:*
+
 ```json
 {
     "success": true,
@@ -198,9 +205,7 @@ If you want to update a user, you can send a DELETE request to /users/{userId}
 
 *Example code:*
 
-```php
-$client->delete('users/2', []);
-```
+{% include 'api_badge.twig' with {'route': '/api/users/2', 'method': 'DELETE'} %}
 
 *Example output:*
 ```json

--- a/source/developers-guide/rest-api/customer-streams/index.md
+++ b/source/developers-guide/rest-api/customer-streams/index.md
@@ -15,9 +15,6 @@ subgroup: REST API
 In this article, you will find examples which demonstrate how to create, delete, get and index **[Customer Streams](/developers-guide/customer-streams-extension)** and how to rebuild the search index. For each scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[REST API Basics](/developers-guide/rest-api/)** if you haven't yet.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
-
 ## Build Search Index
 To assure high performance, even when working with large data sets,
 all customer must be indexed regularly. The index is basically a cache which
@@ -30,13 +27,16 @@ contains all information which are needed for the Customer Stream module.
 
 
 *Example code:*
-```php
-$client->post('customer_streams', [
-    'buildSearchIndex' => true
-]);
+
+{% include 'api_badge.twig' with {'route': '/api/customer_streams', 'method': 'POST', 'body': true} %}
+```json
+{
+  "buildSearchIndex": true
+}
 ```
 
 *Example output:*
+
 ```json
 {
     "success": true
@@ -67,16 +67,20 @@ Define a new dynamic stream.
 | indexStream         | boolean      |                     | Stream will be index if set to true                                     |
 
 *Example code:*
-```php
-$client->post('customer_streams', [
-    'name' => 'Dynamic api stream',
-    'static' => false,
-    'description' => 'Stream created over the api which will be indexed immediately',
-    'conditions' => '{"Shopware\\\\Bundle\\\\CustomerSearchBundle\\\\Condition\\\\HasOrderCountCondition":{"operator":"=","minimumOrderCount":1}}',
-    'indexStream' => true
-]);
+
+{% include 'api_badge.twig' with {'route': '/api/customer_streams', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "Dynamic api stream",
+    "static": false,
+    "description": "Stream created over the api which will be indexed immediately",
+    "conditions": "{\"Shopware\\\\Bundle\\\\CustomerSearchBundle\\\\Condition\\\\HasOrderCountCondition\":{\"operator\":\"=\",\"minimumOrderCount\":1}}",
+    "indexStream": true
+}
 ```
+
 *Example output:*
+
 ```json
 {
     "success": true,
@@ -102,16 +106,22 @@ Define a new static stream and assign customers to it.
 
 
 *Example code:*
-```php
-$client->post('customer_streams', [
-    'name' => 'Static api stream',
-    'static' => true,
-    'description' => 'Static stream created over the api',
-    'customers' => [1,2]
-]);
+
+{% include 'api_badge.twig' with {'route': '/api/customer_streams', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "Static api stream",
+    "static": true,
+    "description": "Static stream created over the api",
+    "customers": [
+        1,
+        2
+    ]
+}
 ```
 
 *Example output:*
+
 ```json
 {
     "success": true,
@@ -131,13 +141,15 @@ $client->post('customer_streams', [
 
 *Example code:*
 
-```php
-$client->put('customer_streams/' . (int) $response['data']['id'], [
-    'indexStream' => true,
-]);
+{% include 'api_badge.twig' with {'route': '/api/customer_streams/42', 'method': 'PUT', 'body': true} %}
+```json
+{
+  "indexStream": true
+}
 ```
 
 *Example output:*
+
 ```json
 {
     "success": true,
@@ -165,14 +177,17 @@ You can also define an offset/limit to process the stream in chunks.
 | sortings            | string array |                     | Sorting handler which will be applied to the result set                |
 
 *Example code:*
-```php
-$client->get('customer_streams/6', [
-    'conditions' => '{"Shopware\\\\Bundle\\\\CustomerSearchBundle\\\\Condition\\\\HasOrderCountCondition":{"operator":"=>","minimumOrderCount":1}}',
-    'sortings' => '{"Shopware\\\\Bundle\\\\CustomerSearchBundle\\\\Sorting\\\\NumberSorting":{"direction":"DESC"}}'
-]);
+
+{% include 'api_badge.twig' with {'route': '/api/customer_streams/6', 'method': 'GET', 'body': true} %}
+```json
+{
+    "conditions": "{\"Shopware\\\\Bundle\\\\CustomerSearchBundle\\\\Condition\\\\HasOrderCountCondition\":{\"operator\":\"=>\",\"minimumOrderCount\":1}}",
+    "sortings": "{\"Shopware\\\\Bundle\\\\CustomerSearchBundle\\\\Sorting\\\\NumberSorting\":{\"direction\":\"DESC\"}}"
+}
 ```
 
 *Example output:*
+
 ```json
 {
     "data": [
@@ -211,9 +226,8 @@ $client->get('customer_streams/6', [
 List all streams and their attributes.
 
 *Example code:*
-```php
-$client->get('customer_streams/');
-```
+
+{% include 'api_badge.twig' with {'route': '/api/customer_streams', 'method': 'GET'} %}
 
 *Example output:*
 ```json

--- a/source/developers-guide/rest-api/examples/article/index.md
+++ b/source/developers-guide/rest-api/examples/article/index.md
@@ -17,28 +17,16 @@ subgroup: REST API
 In this article, you will find examples of the `article` resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[article API resource](/developers-guide/rest-api/api-resource-article/)** if you haven't yet, to get more information about the article resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**. One of its advantages is that, instead of providing query arguments directly in the URL, you can do so by means of method argument. The client application will, internally, handle the full URL generation. You can also place variables using this technique. An example call would look like this:
-
-```
-$client->post('articles', array(
-    'name' => 'NewId',
-    'taxId' => 1,
-    'mainDetail' => array(
-        'number' => 'SW123456'
-    )
-));
-```
-
 ## Example 1 - GET
 These example show you how to obtain information about a single product, by using either its ID or product number. The API calls look, respectively, like this:
-```
-$client->get('articles/3');
-$client->get('articles/SW10003?useNumberAsId=true');
-```
+
+{% include 'api_badge.twig' with {'route': '/api/articles/3', 'method': 'GET'} %}
+
+{% include 'api_badge.twig' with {'route': '/api/articles/SW10003?useNumberAsId=true', 'method': 'GET'} %}
 
 ### Result:
 
-```
+```json
 {
    "data":{
       "id":3,
@@ -285,7 +273,7 @@ $client->get('articles/SW10003?useNumberAsId=true');
       "translations":{
          "2":{
             "name":"Munsterland Aperitif 16%",
-            "descriptionLong":"<p>Io copia moeror immo pro audio modestia. Permaneo animosus etsi furax, aversor, faenum Pecus, mus me dux ferociter interpellatio certo. infrequentia Illis Quamquam Invidus, indutus [...] "
+            "descriptionLong":"<p>Io copia moeror immo pro audio modestia. Permaneo animosus etsi furax, aversor, faenum Pecus, mus me dux ferociter interpellatio certo. infrequentia Illis Quamquam Invidus, indutus [...] ",
             "shopId":2
          }
       }
@@ -298,19 +286,14 @@ $client->get('articles/SW10003?useNumberAsId=true');
 This example shows you how to obtain information about a product list.
 With the optional `limit` parameter, it's possible to specify how many products you wish the API call to return.
 
-```
-$client->get('articles');
-$client->get('articles?limit=2');
-```
+{% include 'api_badge.twig' with {'route': '/api/articles?limit=2', 'method': 'GET'} %}
 
 A maximum of 1000 entries is returned. By using the `start` parameter you can get the following entries.
 
-```
-$client->get('articles?start=1001');
-```
+{% include 'api_badge.twig' with {'route': '/api/articles?start=1001', 'method': 'GET'} %}
 
 ### Result
-```
+```json
 {
    "data":[
       {
@@ -376,13 +359,16 @@ $client->get('articles?start=1001');
 ## Example 3 - Update product data
 To update a product it's always required to provide the id of the product to update.
 In this example, we will update the name of the product with the id 3
+
+{% include 'api_badge.twig' with {'route': '/api/articles/3', 'method': 'PUT', 'body': true} %}
+```json
+{
+  "name": "NewName"
+}
 ```
-$client->put('articles/3', array(
-    'name' => 'NewName'
-));
-```
+
 ### Result
-```
+```json
 {
    "success":true,
    "data":{
@@ -397,152 +383,193 @@ To delete a product, it's always required to provide the id of the product to de
 
 **Attention, this action can not be undone**
 
-```
-$client->delete('articles/3');
-```
+{% include 'api_badge.twig' with {'route': '/api/articles/3', 'method': 'DELETE'} %}
 
 ### Result
-```
+```json
 {
-    success: true
+    "success": true
 }
 ```
 
 ## Example 5 - Product configuration / variation
 
 ### Step 1 - Create a new product
-```
-$minimalTestArticle = array(
-    'name' => 'Sport Shoes',
-    'active' => true,
-    'tax' => 19,
-    'supplier' => 'Sport Shoes Inc.',
-    'categories' => array(
-        array('id' => 15),
-    ),
-    'mainDetail' => array(
-        'number' => 'turn',
-        'active' => true,
-        'prices' => array(
-            array(
-                'customerGroupKey' => 'EK',
-                'price' => 999,
-            ),
-        )
-    ),
-);
 
-$client->post('articles', $minimalTestArticle);
-
-
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "Sport Shoes",
+    "active": true,
+    "tax": 19,
+    "supplier": "Sport Shoes Inc.",
+    "categories": [
+        {
+            "id": 15
+        }
+    ],
+    "mainDetail": {
+        "number": "turn",
+        "active": true,
+        "prices": [
+            {
+                "customerGroupKey": "EK",
+                "price": 999
+            }
+        ]
+    }
+}
 ```
 
 
 ### Step 2 - Update the created product
-```
-$updateArticle = array(
-   'configuratorSet' => array(
-        'groups' => array(
-            array(
-                'name' => 'Size',
-                'options' => array(
-                    array('name' => 'S'),
-                    array('name' => 'M'),
-                    array('name' => 'L'),
-                    array('name' => 'XL'),
-                    array('name' => 'XXL'),
-                )
-            ),
-            array(
-                'name' => 'Color',
-                'options' => array(
-                    array('name' => 'White'),
-                    array('name' => 'Yellow'),
-                    array('name' => 'Blue'),
-                    array('name' => 'Black'),
-                    array('name' => 'Red'),
-                )
-            ),
-        )
-    ),
-    'taxId'      => 1,
-    'variants' => array(
-        array(
-            'isMain' => true,
-            'number' => 'turn',
-            'inStock' => 15,
-            'additionaltext' => 'L / Black',
-            'configuratorOptions' => array(
-                array('group' => 'Size', 'option' => 'L'),
-                array('group' => 'Color', 'option' => 'Black'),
-            ),
-            'prices' => array(
-                array(
-                    'customerGroupKey' => 'EK',
-                    'price' => 1999,
-                ),
-            )
-        ),
-        array(
-            'isMain' => false,
-            'number' => 'turn.1',
-            'inStock' => 15,
-            'additionaltext' => 'S / Black',
-            'configuratorOptions' => array(
-                array('group' => 'Size', 'option' => 'S'),
-                array('group' => 'Color', 'option' => 'Black'),
-            ),
-            'prices' => array(
-                array(
-                    'customerGroupKey' => 'EK',
-                    'price' => 999,
-                ),
-            )
-        ),
-        array(
-            'isMain' => false,
-            'number' => 'turn.2',
-            'inStock' => 15,
-            'additionaltext' => 'S / Red',
-            'configuratorOptions' => array(
-                array('group' => 'Size', 'option' => 'S'),
-                array('group' => 'Color', 'option' => 'Red'),
-            ),
-            'prices' => array(
-                array(
-                    'customerGroupKey' => 'EK',
-                    'price' => 999,
-                ),
-            )
-        ),
-        array(
-            'isMain' => false,
-            'number' => 'turn.3',
-            'inStock' => 15,
-            'additionaltext' => 'XL / Red',
-            'configuratorOptions' => array(
-                array('group' => 'Size', 'option' => 'XL'),
-                array('group' => 'Color', 'option' => 'Red'),
-            ),
-            'prices' => array(
-                array(
-                    'customerGroupKey' => 'EK',
-                    'price' => 999,
-                ),
-            )
-        )
-    )
-);
 
-$client->put('articles/193', $updateArticle);
-
+{% include 'api_badge.twig' with {'route': '/api/articles/193', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "configuratorSet": {
+        "groups": [
+            {
+                "name": "Size",
+                "options": [
+                    {
+                        "name": "S"
+                    },
+                    {
+                        "name": "M"
+                    },
+                    {
+                        "name": "L"
+                    },
+                    {
+                        "name": "XL"
+                    },
+                    {
+                        "name": "XXL"
+                    }
+                ]
+            },
+            {
+                "name": "Color",
+                "options": [
+                    {
+                        "name": "White"
+                    },
+                    {
+                        "name": "Yellow"
+                    },
+                    {
+                        "name": "Blue"
+                    },
+                    {
+                        "name": "Black"
+                    },
+                    {
+                        "name": "Red"
+                    }
+                ]
+            }
+        ]
+    },
+    "taxId": 1,
+    "variants": [
+        {
+            "isMain": true,
+            "number": "turn",
+            "inStock": 15,
+            "additionaltext": "L \/ Black",
+            "configuratorOptions": [
+                {
+                    "group": "Size",
+                    "option": "L"
+                },
+                {
+                    "group": "Color",
+                    "option": "Black"
+                }
+            ],
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "price": 1999
+                }
+            ]
+        },
+        {
+            "isMain": false,
+            "number": "turn.1",
+            "inStock": 15,
+            "additionaltext": "S \/ Black",
+            "configuratorOptions": [
+                {
+                    "group": "Size",
+                    "option": "S"
+                },
+                {
+                    "group": "Color",
+                    "option": "Black"
+                }
+            ],
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "price": 999
+                }
+            ]
+        },
+        {
+            "isMain": false,
+            "number": "turn.2",
+            "inStock": 15,
+            "additionaltext": "S \/ Red",
+            "configuratorOptions": [
+                {
+                    "group": "Size",
+                    "option": "S"
+                },
+                {
+                    "group": "Color",
+                    "option": "Red"
+                }
+            ],
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "price": 999
+                }
+            ]
+        },
+        {
+            "isMain": false,
+            "number": "turn.3",
+            "inStock": 15,
+            "additionaltext": "XL \/ Red",
+            "configuratorOptions": [
+                {
+                    "group": "Size",
+                    "option": "XL"
+                },
+                {
+                    "group": "Color",
+                    "option": "Red"
+                }
+            ],
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "price": 999
+                }
+            ]
+        }
+    ]
+}
 ```
 
 ### Result
 
-```
+```json
 {
-    success: true
+    "success": true
 }
 ```
 
@@ -551,150 +578,141 @@ $client->put('articles/193', $updateArticle);
 It's also possible to add product properties using the `article` resource.
 In order to perform this action, an array like this is required:
 
-```
-$filterTest = array(
-    'name' => 'My awesome liquor',
-    'description' => 'hmmmmm',
-
-    'active' => true,
-    'taxId'      => 1,
-
-    'mainDetail' => array(
-        'number' => 'brand1',
-        'inStock' => 15,
-        'active' => true,
-
-        'prices' => array(
-            array(
-                'customerGroupKey' => 'EK',
-                'from'  => 1,
-                'price' => 50
-            )
-        )
-    ),
-
-    'filterGroupId' => 1,
-    'propertyValues' => array(
-        array(
-            'option' => array('name' => "Alcohol content"),
-            'value' => '10%'
-        ),
-        array(
-            'option' => array('name' => "Color"),
-            'value' => 'rot'
-        )
-    )
-);
-
-$client->post('articles', $filterTest);
-
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "My awesome liquor",
+    "description": "hmmmmm",
+    "active": true,
+    "taxId": 1,
+    "mainDetail": {
+        "number": "brand1",
+        "inStock": 15,
+        "active": true,
+        "prices": [
+            {
+                "customerGroupKey": "EK",
+                "from": 1,
+                "price": 50
+            }
+        ]
+    },
+    "filterGroupId": 1,
+    "propertyValues": [
+        {
+            "option": {
+                "name": "Alcohol content"
+            },
+            "value": "10%"
+        },
+        {
+            "option": {
+                "name": "Color"
+            },
+            "value": "rot"
+        }
+    ]
+}
 ```
 
 Options (`option`) and values (`value`) can be identified by name (see example above) or by identifier (`id`). Since the values within option and options are unique in groups, it's possible to automatically recognize if a new one has to be added to the shop, or if an existing entry has to be updated. PropertyGroups (`filterGroupID`) have to be added through another resource **[PropertyGroups](../../api-resource-property-group)**.
 
-```
-$properties = array(
-     "name" => "Liquor",
-     'position' => 1,
-     'comparable' => 1,
-     'sortmode' => 2
-);
-
-$client->post('propertyGroups', $properties);
-
+{% include 'api_badge.twig' with {'route': '/api/propertyGroups', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "Liquor",
+    "position": 1,
+    "comparable": 1,
+    "sortmode": 2
+}
 ```
 The returned identifier may be set as `filterGroupId`, just like the example `$filterTest` shows.
 
-## Example 7 - Link new or existing images to a property 
+## Example 7 - Link new or existing images to a property
 
 Its possible to assign images to a specific product property.
 
-```
-$filterTest = array(
-    'name' => 'My awesome liquor',
-    'description' => 'hmmmmm',
-
-    'active' => true,
-    'taxId'      => 1,
-
-    'mainDetail' => array(
-        'number' => 'brand1',
-        'inStock' => 15,
-        'active' => true,
-
-        'prices' => array(
-            array(
-                'customerGroupKey' => 'EK',
-                'from'  => 1,
-                'price' => 50
-            )
-        )
-    ),
-    
-    'images' => array(
-        array(
-            'link' => 'http://example.org/test.jpg',
-            'main' => 1,
-            'position' => 1,
-            'options' => array(
-                'name' => 'Alcohol content'
-            )
-        ),
-        array(
-            'mediaId' => 57,
-            'main' => 0,
-            'position' => 2,
-            'options' => array(
-                'name' => 'Color'
-            )
-        )
-    ),
-
-    'filterGroupId' => 1,
-    'propertyValues' => array(
-        array(
-            'option' => array('name' => "Alcohol content"),
-            'value' => '10%'
-        ),
-        array(
-            'option' => array('name' => "Color"),
-            'value' => 'rot'
-        )
-    )
-);
-
-$client->post('articles', $filterTest);
-
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "My awesome liquor",
+    "description": "hmmmmm",
+    "active": true,
+    "taxId": 1,
+    "mainDetail": {
+        "number": "brand1",
+        "inStock": 15,
+        "active": true,
+        "prices": [
+            {
+                "customerGroupKey": "EK",
+                "from": 1,
+                "price": 50
+            }
+        ]
+    },
+    "images": [
+        {
+            "link": "http:\/\/example.org\/test.jpg",
+            "main": 1,
+            "position": 1,
+            "options": {
+                "name": "Alcohol content"
+            }
+        },
+        {
+            "mediaId": 57,
+            "main": 0,
+            "position": 2,
+            "options": {
+                "name": "Color"
+            }
+        }
+    ],
+    "filterGroupId": 1,
+    "propertyValues": [
+        {
+            "option": {
+                "name": "Alcohol content"
+            },
+            "value": "10%"
+        },
+        {
+            "option": {
+                "name": "Color"
+            },
+            "value": "rot"
+        }
+    ]
+}
 ```
 
 ## Example 8 - Creating and referencing units
 
 It's possible to specify units using the `unit` key. The snippet below shows how:
 
-```
-$articleWithUnit = array(
-    'name' => 'Sport shoes',
-    'tax' => 19,
-    'supplier' => 'Sport shoes Inc.',
-    'active' => true,
-
-    'mainDetail' => array(
-        'number' => 'turn33',
-        'active' => true,
-        'prices' => array(
-            array(
-                'customerGroupKey' => 'EK',
-                'price' => 999,
-            ),
-        ),
-        'unit' => array(
-            'unit' => 'xyz',
-            'name' => 'New Unit'
-        )
-    ),
-);
-
-$client->post('articles', articleWithUnit);
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "Sport shoes",
+    "tax": 19,
+    "supplier": "Sport shoes Inc.",
+    "active": true,
+    "mainDetail": {
+        "number": "turn33",
+        "active": true,
+        "prices": [
+            {
+                "customerGroupKey": "EK",
+                "price": 999
+            }
+        ],
+        "unit": {
+            "unit": "xyz",
+            "name": "New Unit"
+        }
+    }
+}
 
 ```
 
@@ -702,187 +720,231 @@ The API itself checks if the unit already exist. If it does, the old unit will b
 
 ## Further examples
 
-```
-$testArticle = array(
-    'name'     => 'NewTestArticle',
-    'active'   => true,
-    'tax'      => 19,          // alternatively 'taxId' => 1,
-    'supplier' => 'Test Supplier', // alternatively 'supplierId' => 2,
+### Linking images
 
-    'categories' => array(
-        array('id' => 15),
-        array('id' => 16),
-    ),
-
-    'images' => array(
-        array('link' => 'http://lorempixel.com/640/480/food/'),     // allowed link options http, https, file, ftp
-        array('link' => 'http://lorempixel.com/640/480/food/'),     // e.g. file:///var/www/shopware/media/upload/test.jpg
-    ),
-
-    'mainDetail' => array(
-        'number' => 'swTEST' . uniqid(),
-        'active' => true,
-        'inStock' => 16,
-        'prices' => array(
-            array(
-                'customerGroupKey' => 'EK',
-                'price' => 99.34,
-            ),
-        )
-    ),
-);
-$client->post('articles', $testArticle);
-```
-
-```
-$updateInStock = array(
-    'mainDetail' => array(
-        'inStock' => 66
-    )
-);
-$client->put('articles/3', $updateInStock);
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "NewTestArticle",
+    "active": true,
+    "tax": 19,
+    "supplier": "Test Supplier",
+    "categories": [
+        {
+            "id": 15
+        },
+        {
+            "id": 16
+        }
+    ],
+    "images": [
+        {
+            "link": "http:\/\/lorempixel.com\/640\/480\/food\/"
+        },
+        {
+            "link": "http:\/\/lorempixel.com\/640\/480\/food\/"
+        }
+    ],
+    "mainDetail": {
+        "number": "swTEST5d9b1a3c6521f",
+        "active": true,
+        "inStock": 16,
+        "prices": [
+            {
+                "customerGroupKey": "EK",
+                "price": 99.34
+            }
+        ]
+    }
+}
 ```
 
-```
-$updateVariantInStock = array(
-    'variants' => array(
-        array(
-            // update per primary key
-            'id'      => 726,
-            'inStock' => 99,
-        ),
-        array(
-            // update per ordernumber key
-            'number' => 'SW10204.5',
-            'inStock' => 999,
-        ),
-    )
-);
-$client->put('articles/205', $updateVariantInStock);
+### Updating the number of products in stock
+
+{% include 'api_badge.twig' with {'route': '/api/articles/3', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "mainDetail": {
+        "inStock": 66
+    }
+}
 ```
 
+### Updating the number of variants in stock
+
+{% include 'api_badge.twig' with {'route': '/api/articles/205', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "variants": [
+        {
+            "id": 726,
+            "inStock": 99
+        },
+        {
+            "number": "SW10204.5",
+            "inStock": 999
+        }
+    ]
+}
 ```
 
-$configuratorArticle = array(
-    'name' => 'ConfiguratorTest',
-    'description' => 'A test article',
-    'descriptionLong' => '<p>I\'m a <b>test article</b></p>',
-    'active' => true,
-    'taxId' => 1,
-    'supplierId' => 2,
+### Creating a configuratorSet and variants
 
-    'categories' => array(
-        array('id' => 15),
-    ),
-
-   'mainDetail' => array(
-        'number' => 'swTEST' . uniqid(),
-        'active' => true,
-        'prices' => array(
-            array(
-                'customerGroupKey' => 'EK',
-                'price' => 999,
-            ),
-        )
-    ),
-
-    'configuratorSet' => array(
-        'groups' => array(
-            array(
-                'name' => 'Size',
-                'options' => array(
-                    array('name' => 'S'),
-                    array('name' => 'M'),
-                    array('name' => 'L'),
-                    array('name' => 'XL'),
-                    array('name' => 'XXL'),
-                )
-            ),
-            array(
-                'name' => 'Color',
-                'options' => array(
-                    array('name' => 'White'),
-                    array('name' => 'Yellow'),
-                    array('name' => 'Blue'),
-                    array('name' => 'Black'),
-                )
-            ),
-        )
-    ),
-    'variants' => array(
-        array(
-            'isMain' => true,
-            'number' => 'swTEST' . uniqid(),
-            'inStock' => 15,
-            'additionaltext' => 'S / Schwarz',
-            'configuratorOptions' => array(
-                array('group' => 'Size', 'option' => 'S'),
-                array('group' => 'Color', 'option' => 'Black'),
-            ),
-            'prices' => array(
-                array(
-                    'customerGroupKey' => 'EK',
-                    'price' => 999,
-                ),
-            )
-        ),
-        array(
-            'number' => 'swTEST' . uniqid(),
-            'inStock' => 10,
-            'additionaltext' => 'S / Weiß',
-            'configuratorOptions' => array(
-                array('group' => 'Size', 'option' => 'S'),
-                array('group' => 'Color', 'option' => 'White'),
-            ),
-            'prices' => array(
-                array(
-                    'customerGroupKey' => 'EK',
-                    'price' => 888,
-                ),
-            ),
-            'attribute' => array(
-                'attr1' => 'S/White Attr1',
-                'attr2' => 'SomeText',
-            ),
-        ),
-        array(
-            'number' => 'swTEST' . uniqid(),
-            'inStock' => 5,
-            'additionaltext' => 'XL / Blue',
-            'configuratorOptions' => array(
-                array('group' => 'Size', 'option' => 'XL'),
-                array('group' => 'Color', 'option' => 'Blue'),
-            ),
-            'prices' => array(
-                array(
-                    'customerGroupKey' => 'EK',
-                    'price' => 555,
-                ),
-            )
-        )
-    ),
-);
-
-$client->post('articles', $configuratorArticle);
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "ConfiguratorTest",
+    "description": "A test article",
+    "descriptionLong": "<p>I'm a **test article<\/b><\/p>",
+    "active": true,
+    "taxId": 1,
+    "supplierId": 2,
+    "categories": [
+        {
+            "id": 15
+        }
+    ],
+    "mainDetail": {
+        "number": "swTEST5d9b1a9cbcc9d",
+        "active": true,
+        "prices": [
+            {
+                "customerGroupKey": "EK",
+                "price": 999
+            }
+        ]
+    },
+    "configuratorSet": {
+        "groups": [
+            {
+                "name": "Size",
+                "options": [
+                    {
+                        "name": "S"
+                    },
+                    {
+                        "name": "M"
+                    },
+                    {
+                        "name": "L"
+                    },
+                    {
+                        "name": "XL"
+                    },
+                    {
+                        "name": "XXL"
+                    }
+                ]
+            },
+            {
+                "name": "Color",
+                "options": [
+                    {
+                        "name": "White"
+                    },
+                    {
+                        "name": "Yellow"
+                    },
+                    {
+                        "name": "Blue"
+                    },
+                    {
+                        "name": "Black"
+                    }
+                ]
+            }
+        ]
+    },
+    "variants": [
+        {
+            "isMain": true,
+            "number": "swTEST5d9b1a9cbcc9f",
+            "inStock": 15,
+            "additionaltext": "S \/ Schwarz",
+            "configuratorOptions": [
+                {
+                    "group": "Size",
+                    "option": "S"
+                },
+                {
+                    "group": "Color",
+                    "option": "Black"
+                }
+            ],
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "price": 999
+                }
+            ]
+        },
+        {
+            "number": "swTEST5d9b1a9cbcca0",
+            "inStock": 10,
+            "additionaltext": "S \/ Wei\u00df",
+            "configuratorOptions": [
+                {
+                    "group": "Size",
+                    "option": "S"
+                },
+                {
+                    "group": "Color",
+                    "option": "White"
+                }
+            ],
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "price": 888
+                }
+            ],
+            "attribute": {
+                "attr1": "S\/White Attr1",
+                "attr2": "SomeText"
+            }
+        },
+        {
+            "number": "swTEST5d9b1a9cbcca1",
+            "inStock": 5,
+            "additionaltext": "XL \/ Blue",
+            "configuratorOptions": [
+                {
+                    "group": "Size",
+                    "option": "XL"
+                },
+                {
+                    "group": "Color",
+                    "option": "Blue"
+                }
+            ],
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "price": 555
+                }
+            ]
+        }
+    ]
+}
 ```
 
-Update SEO category of a product
+### Updating the SEO category of a product
 
+{% include 'api_badge.twig' with {'route': '/api/articles/SW10239?useNumberAsId=true', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "seoCategories": [
+        {
+            "shopId": 1,
+            "categoryId": 15
+        }
+    ],
+    "categories": [
+        {
+            "id": 15
+        }
+    ]
+}
 ```
-$updateSeoCategory = array(
-    'seoCategories' => array(
-        array(
-            'shopId'      => 1,
-            'categoryId' => 15,
-        ),
-    ),
-    'categories' => array(
-        array(
-            'id' => 15
-        )
-    )
-);
-$client->put('articles/SW10239?useNumberAsId=true', $updateSeoCategory);
 
-If you just want to add another seo category, you have to add the value: '__options_seoCategories' => false
-```
+If you just want to add another seo category, you have to add the value: `__options_seoCategories' => false`

--- a/source/developers-guide/rest-api/examples/batch/index.md
+++ b/source/developers-guide/rest-api/examples/batch/index.md
@@ -15,11 +15,9 @@ subgroup: REST API
 In this article, you will find examples of the provided resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[category API resource](/developers-guide/rest-api/api-resource-categories/)** if you haven't yet, to get more information about the category resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
 ## Batch mode
 
-The batch mode allows to create and / or update multiple elements in one request. 
+The batch mode allows to create and / or update multiple elements in one request.
 Notice the list of resources which supports the batch mode.  
 
 The results of the different tasks (create / update) is stacked and returns one result.
@@ -32,23 +30,48 @@ The following resources supports the batch mode.
 
 To use the batch mode, send a PUT request without an id in the URL.
 
-```php
-$restClient->put(
-    'articles/', 
-    array(
-        array('id' => 1, 'name' => '...'),
-        array('id' => 1, 'name' => '...'),
-        array('name' => '...'),
-        array('name' => '...')
-    )
-);
-
-$restClient->delete(
-    'articles/',
-    array(
-        array('id' => 2),
-        array('id' => 4),
-        array('id' => 6)
-    )
-);
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'PUT', 'body': true} %}
+```json
+[
+  {
+    "name": "Lorem",
+    "taxId": 1,
+    "mainDetail": {
+        "number": "SW123456"
+    }
+  },
+  {
+    "name": "Ipsum",
+    "taxId": 1,
+    "mainDetail": {
+        "number": "SW123457"
+    }
+  },
+  {
+    "name": "Dolor",
+    "taxId": 1,
+    "mainDetail": {
+        "number": "SW123458"
+    }
+  }
+]
 ```
+
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'DELETE', 'body': true} %}
+```json
+[
+  {
+    "id": 2
+  },
+  {
+    "id": 4
+  },
+  {
+    "id": 6
+  },
+  {
+    "id": 8
+  }
+]
+```
+

--- a/source/developers-guide/rest-api/examples/cache/index.md
+++ b/source/developers-guide/rest-api/examples/cache/index.md
@@ -15,90 +15,28 @@ subgroup: REST API
 In this article, you will find examples of the provided resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[category API resource](/developers-guide/rest-api/api-resource-categories/)** if you haven't yet, to get more information about the category resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
-
 ## Cache Resources
 
-<table>
-    <thead>
-    <tr>
-        <th>
-            <div>Resources</div>
-        </th>
-        <th >
-            <div>HTTP</div>
-        </th>
-        <th colspan="1">
-        </th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-        <td>
-            $cacheResource-&gt;delete('all');
-        </td>
-        <td>
-            DELETE api/caches/
-        </td>
-        <td colspan="1">
-            <div>Deletes all caches</div>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            $cacheResource-&gt;delete('http');
-        </td>
-        <td>
-            DELETE api/caches/http
-        </td>
-        <td colspan="1">
-            <div>Deletes the HTTP cache</div>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            $cacheResource-&gt;delete('template');
-        </td>
-        <td>
-            DELETE api/caches/template
-        </td>
-        <td colspan="1">
-            <div>Deletes the template cache</div>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            $cacheResource-&gt;getList();
-        </td>
-        <td>
-            GET api/caches/
-        </td>
-        <td colspan="1">
-            <div>Gets the cache information</div>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="1">
-            $cacheResource-&gt;getOne('http'); 
-        </td>
-        <td colspan="1">
-            GET api/caches/http
-        </td>
-        <td colspan="1">
-            <div>Gets the HTTP cache information</div>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="1">
-            $cacheResource-&gt;getOne('template');
-        </td>
-        <td colspan="1">
-            GET api/caches/template
-        </td>
-        <td colspan="1">
-            <div>Gets the template cache information</div>
-        </td>
-    </tr>
-    </tbody>
-</table>
+### Delete all caches
+
+{% include 'api_badge.twig' with {'route': '/api/caches', 'method': 'DELETE'} %}
+
+### Delete the HTTP-cache
+
+{% include 'api_badge.twig' with {'route': '/api/caches/http', 'method': 'DELETE'} %}
+
+### Delete the template cache
+
+{% include 'api_badge.twig' with {'route': '/api/caches/template', 'method': 'DELETE'} %}
+
+### Retrieve information about the cache
+
+{% include 'api_badge.twig' with {'route': '/api/caches', 'method': 'GET'} %}
+
+### Retrieve information about the HTTP-cache
+
+{% include 'api_badge.twig' with {'route': '/api/caches/http', 'method': 'GET'} %}
+
+### Retrieve information about the template-cache
+
+{% include 'api_badge.twig' with {'route': '/api/caches/template', 'method': 'GET'} %}

--- a/source/developers-guide/rest-api/examples/category/index.md
+++ b/source/developers-guide/rest-api/examples/category/index.md
@@ -15,56 +15,51 @@ subgroup: REST API
 In this article, you will find examples of the provided resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[category API resource](/developers-guide/rest-api/api-resource-categories/)** if you haven't yet, to get more information about the category resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
-
 ## Example 1 - Creating a category
 This example adds a sub-category to category 3
 
-```
-$createCategory = [
-    'parentId' => 3,
-    'name'     => 'Test category'
-];
-$client->post('categories', $createCategory);
-
+{% include 'api_badge.twig' with {'route': '/api/categories', 'method': 'POST', 'body': true} %}
+```json
+{
+  "parentId": 3,
+  "name": "Test-category"
+}
 ```
 
 ## Example 2 - Adding categories with attributes and additional fields
 
-```
-
-$categoryData = [
-    'name' => 'Test category',
-    'metaDescription' => 'metaTest',
-    'metaKeywords' => 'keywordTest',
-    'cmsHeadline' => 'headlineTest',
-    'cmsText' => 'cmsTextTest',
-    'active' => true,
-    'noViewSelect' => true,
-    'attribute' => [
-        1 => 'Attribute1',
-        2 => 'Attribute2',
-    ]
-];
-$client->post('categories', $categoryData );
-
+{% include 'api_badge.twig' with {'route': '/api/categories', 'method': 'POST', 'body': true} %}
+```json
+{
+  "name": "Test-category",
+  "metaDescription": "metaTest",
+  "metaKeywords": "keywordTest",
+  "cmsHeadline": "headlineTest",
+  "cmsText": "cmsTextTest",
+  "active": true,
+  "noViewSelect": true,
+  "attribute": {
+    "1": "Attribute1",
+    "2": "Attribute2"
+  }
+}
 ```
 
 ## Example 3 - Create a category with translation
 
-```
-$categoryData = [
-    'name' => 'Test category',
-    'attribute' => [
-        1 => "Attr1",
-    ],
-    'translations' => [
-        2 => [
-            'shopId' => 2,
-            'description' => 'Test category, english translation',
-            '__attribute_attribute1' => 'Attr1 English'
-        ]
-    ]
-];
+{% include 'api_badge.twig' with {'route': '/api/categories', 'method': 'POST', 'body': true} %}
+```json
+{
+  "name": "Test-category",
+  "attribute": {
+    "1": "Attr1"
+  },
+  "translations": {
+    "2": {
+      "shopId": 2,
+      "description": "Test category, english translation",
+      "__attribute_attribute1": "Attr1 English"
+    }
+  }
+}
 ```

--- a/source/developers-guide/rest-api/examples/customer/index.md
+++ b/source/developers-guide/rest-api/examples/customer/index.md
@@ -17,21 +17,17 @@ subgroup: REST API
 In this article, you will find examples of the customer resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[customer API resource](/developers-guide/rest-api/api-resource-customer)** if you haven't yet, to get more information about the customer resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
 ## Example 1 - Get all customers
 
 In this example, you can see how it's possible to get a list of all customers in a shop and how to limit the result to a fixed number.
 
-```
-$client->get('customers');
-$client->get('customers?limit=20');
+{% include 'api_badge.twig' with {'route': '/api/customers', 'method': 'GET'} %}
 
-```
+{% include 'api_badge.twig' with {'route': '/api/customers?limit=20', 'method': 'GET'} %}
 
 ### Result
 
-```
+```json
 {
     "data":[
         {
@@ -103,16 +99,14 @@ $client->get('customers?limit=20');
 
 ```
 
-## Example 2 - Get a specific customer
+## Example 2 - Get a specific customer account
 
-This example shows you how to get a customer by its id
+This example shows you how to get a customer account by its id
 
-```
-$client->get('customers/1');
-```
+{% include 'api_badge.twig' with {'route': '/api/customers/1', 'method': 'GET'} %}
 
 ### Result
-```
+```json
 {
     "data":{
         "number": "20001",
@@ -248,81 +242,82 @@ $client->get('customers/1');
 }
 ```
 
-## Example 3 - Create customer
+## Example 3 - Create a customer account
 
-This shows you how to create a minimalistic customer:
+This shows you how to create a minimalistic customer account:
 
+{% include 'api_badge.twig' with {'route': '/api/customers', 'method': 'POST', 'body': true} %}
+```json
+{
+    "email": "meier@mail.de",
+    "firstname": "Max",
+    "lastname": "Meier",
+    "salutation": "mr",
+    "billing": {
+        "firstname": "Max",
+        "lastname": "Meier",
+        "salutation": "mr",
+        "street": "Musterstrasse 55",
+        "city": "Sch\\u00f6ppingen",
+        "zipcode": "48624",
+        "country": 2
+    }
+}
 ```
-$client->post('customers',  array(
-    'email' => 'meier@mail.de',
-    'firstname' => 'Max',
-    'lastname' => 'Meier',
-    'salutation' => 'mr',
-    'billing' => array(
-        'firstname' => 'Max',
-        'lastname' => 'Meier',
-        'salutation' => 'mr',
-        'street' => 'Musterstrasse 55',
-        'city' => 'Sch\u00f6ppingen',
-        'zipcode' => '48624',
-        'country' => 2
-    )
-));
+
+### Result
+
+```json
+{
+  "id": 15,
+  "location": "https://shop.example.com/api/customers/15"
+}
 ```
 
-## Example 4 - Create customer with Double-Opt-In confirmation
+## Example 4 - Create customer account with Double-Opt-In confirmation
 
 This examples shows how to add a minimalistic customer using `'doubleOptinRegister' => true` to register him during
 Double-Opt-In and `'sendOptinMail' => true` to send him the required E-Mail with a confirmation link to complete his registration:
 
+{% include 'api_badge.twig' with {'route': '/api/customers', 'method': 'POST', 'body': true} %}
+```json
+{
+    "email": "meier@mail.de",
+    "firstname": "Max",
+    "lastname": "Meier",
+    "salutation": "mr",
+    "doubleOptinRegister": true,
+    "sendOptinMail": true,
+    "billing": {
+        "firstname": "Max",
+        "lastname": "Meier",
+        "salutation": "mr",
+        "street": "Musterstrasse 55",
+        "city": "Sch\\u00f6ppingen",
+        "zipcode": "48624",
+        "country": 2
+    }
+}
 ```
-$client->post('customers',  array(
-    'email' => 'meier@mail.de',
-    'firstname' => 'Max',
-    'lastname' => 'Meier',
-    'salutation' => 'mr',
-    'doubleOptinRegister' => true,
-    'sendOptinMail' => true,
-    'billing' => array(
-        'firstname' => 'Max',
-        'lastname' => 'Meier',
-        'salutation' => 'mr',
-        'street' => 'Musterstrasse 55',
-        'city' => 'Sch\u00f6ppingen',
-        'zipcode' => '48624',
-        'country' => 2
-    )
-));
-```
-
-
 
 ### Result
 
-If the customer was created successfully this will be returned:
-
-```
-Array
-(
-    [id] => 15
-    [location] => http://www.ihredomain.de/api/customers/15
-)
+```json
+{
+  "id": 16,
+  "location": "https://shop.example.com/api/customers/16"
+}
 ```
 
-## Example 5 - Update specific customer
+## Example 5 - Update a specific customer account
 
-It's possible to update a customer by passing its identifier and the new fields.
-
-```
-$client->put('customers/1', array(
-    'email' => 'new@mail.de'
-));
-
+{% include 'api_badge.twig' with {'route': '/api/customers/1', 'method': 'PUT', 'body': true} %}
+```json
+{
+  "email": "updated@example.com"
+}
 ```
 
-## Example 6 - Delete a specific customer
+## Example 6 - Delete a specific customer account
 
-```
-$client->delete('customers/1');
-
-```
+{% include 'api_badge.twig' with {'route': '/api/customers/12', 'method': 'DELETE'} %}

--- a/source/developers-guide/rest-api/examples/filter/index.md
+++ b/source/developers-guide/rest-api/examples/filter/index.md
@@ -15,13 +15,10 @@ subgroup: REST API
 In this article, you will find examples of the provided resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[category API resource](/developers-guide/rest-api/api-resource-categories/)** if you haven't yet, to get more information about the category resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
-
 ## Filter by language
 
 In this article you can read more about the filter function. The filter functionality is for limiting the result.
-  
+
 ```php
 $translationResource->getList(0, 10, array(
     array('property' => 'translation.shopId', 'value' => 2)
@@ -38,7 +35,7 @@ $translationResource->getList(0, 1, array(
 ));
 ```
 
-<b>Example output:</b>
+**Example output:**
 
 ```php
 array('total' => 246, 'data' => array(
@@ -71,4 +68,26 @@ array('total' => 246, 'data' => array(
         'shopId' => '2'
     )
 ));
+```
+
+## Example 1 - Filter products by name
+
+{% include 'api_badge.twig' with {'route': '/api/articles?filter[name]=Lorem', 'method': 'GET'} %}
+
+{% include 'api_badge.twig' with {'route': '/api/articles?filter[0][property]=name&filter[0][value]=Ipsum%', 'method': 'GET'} %}
+
+{% include 'api_badge.twig' with {'route': '/api/articles?filter[0][property]=name&filter[0][expression]=LIKE&filter[0][value]=%Dolor%', 'method': 'GET'} %}
+
+### Result
+
+```json
+{
+    "data": [
+        {},
+        {},
+        {}
+    ],
+    "success": true,
+    "total": 3
+}
 ```

--- a/source/developers-guide/rest-api/examples/media/index.md
+++ b/source/developers-guide/rest-api/examples/media/index.md
@@ -17,9 +17,6 @@ subgroup: REST API
 In this article, you will find examples of the provided resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[media API resource](/developers-guide/rest-api/api-resource-media/)** if you haven't yet, to get more information about the media resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
-
 ## Image assignment
 
 With the variant resource it is possible to create images for variants. This configuration is implemented in two ways.
@@ -35,177 +32,259 @@ If no image with the given media ID exists, the resource creates a new product i
 Passing an image URL.
 This function is copied from the article image array. The image URL can be a local file, base64, or some other type supported by the article and media resource.
 
-<b>Types:</b>
+**Types:**
 http, https, file, ftp, ftps
 Example for file on server `file:///var/www/shopware/media/upload/test.jpg`
 
-Both configurations automatically create the child data sets in <code>s_articles_img</code> and the relation for the backend configuration.
+Both configurations automatically create the child data sets in `s_articles_img` and the relation for the backend configuration.
 
-<b>Example:</b> (Updates an existing variant using the resource <code>variants</code> and assigns two types of images.)
+**Example:** (Updates an existing variant using the resource `variants` and assigns two types of images.)
 
-```php
-// PUT /api/variants/1042
-array(
-    'id' => 1042,
-    'articleId' => 278,
-    'images' => array(
-        array('mediaId' => 2),
-        array('link' => 'http://.....')
-    ),
-);
+{% include 'api_badge.twig' with {'route': '/api/variants/1042', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "id": 1042,
+    "articleId": 278,
+    "images": [
+        {
+            "mediaId": 2
+        },
+        {
+            "link": "http:\/\/example.com\/example.png"
+        }
+    ]
+}
 ```
 
 ## The configuration for image assignment
 
 In addition to the image mapping option, it is possible to create new assignments by using the article resource.
-This way generates no child data sets in <code>s_articles_img</code> because a product could contain 10.000 variants. The generation for each relation would be too slow.
+This way generates no child data sets in `s_articles_img` because a product could contain 10.000 variants. The generation for each relation would be too slow.
 It is necessary to call a additional API request to generate images for each variant. 
 
-The following example creates a product with two variants. The first variant with <code>"0,2 Liter"</code> and the second variant with <code>"0,5 Liter"</code>.
-In addition the <code> "0,2 Liter"</code> variant becomes a variant image.
+The following example creates a product with two variants. The first variant with `"0,2 Liter"` and the second variant with `"0,5 Liter"`.
+In addition a variant image is assigned to the `"0,2 Liter"` variant.
 
-```php
-array(
-    'name' => 'Testartikel',
-    'description' => 'Test description',
-    'active' => true,
-    'mainDetail' => array(
-        'number' => 'swTEST52b04c97da770',
-        'inStock' => 15,
-        'unitId' => 1,
-        'prices' => array(
-            array('customerGroupKey' => 'EK','from' => 1,'to' => '-', 'price' => 400)
-        )
-    ),
-    'taxId' => 1,
-    'supplierId' => 2,
-    'images' => array(
-        array(
-            'mediaId' => 236,
-            'options' => array(
-                array(
-                    array('name' => '0,2 Liter')
-                )
-            )
-        )
-    ),
-    'configuratorSet' => array(
-        'name' => 'Test-Set',
-        'groups' => array(
-            array(
-                'id' => 5,
-                'name' => 'Flascheninhalt',
-                'options' => array(
-                    array('id' => 11, 'name' => '0,2 Liter'),
-                    array('id' => 35, 'name' => '0,5 Liter'),
-                )
-            )
-        )
-    ),
-    'variants' => array(
-        array(
-            'number' => 'swTEST52b04c97dd280',
-            'inStock' => 100,
-            'unitId' => 1,
-            'prices' => array(
-                array('customerGroupKey' => 'EK','from' => 1,'to' => '-','price' => 400)
-            ),
-            'configuratorOptions' => array(
-                array('option' => '0,2 Liter', 'groupId' => 5)
-            )
-        ),
-        array(
-            'number' => 'swTEST52b04c97dd28f',
-            'inStock' => 100,
-            'unitId' => 1,
-            'prices' => array(
-                array('customerGroupKey' => 'EK', 'from' => 1, 'to' => '-', 'price' => 400)
-            ),
-            'configuratorOptions' => array(
-                array('option' => '0,5 Liter', 'groupId' => 5)
-            )
-        )
-    )
-);
+{% include 'api_badge.twig' with {'route': '/api/articles', 'method': 'POST', 'body': true} %}
+```json
+{
+    "name": "Testartikel",
+    "description": "Test description",
+    "active": true,
+    "mainDetail": {
+        "number": "swTEST52b04c97da770",
+        "inStock": 15,
+        "unitId": 1,
+        "prices": [
+            {
+                "customerGroupKey": "EK",
+                "from": 1,
+                "to": "-",
+                "price": 400
+            }
+        ]
+    },
+    "taxId": 1,
+    "supplierId": 2,
+    "images": [
+        {
+            "mediaId": 236,
+            "options": [
+                [
+                    {
+                        "name": "0,2 Liter"
+                    }
+                ]
+            ]
+        }
+    ],
+    "configuratorSet": {
+        "name": "Test-Set",
+        "groups": [
+            {
+                "id": 5,
+                "name": "Flascheninhalt",
+                "options": [
+                    {
+                        "id": 11,
+                        "name": "0,2 Liter"
+                    },
+                    {
+                        "id": 35,
+                        "name": "0,5 Liter"
+                    }
+                ]
+            }
+        ]
+    },
+    "variants": [
+        {
+            "number": "swTEST52b04c97dd280",
+            "inStock": 100,
+            "unitId": 1,
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "from": 1,
+                    "to": "-",
+                    "price": 400
+                }
+            ],
+            "configuratorOptions": [
+                {
+                    "option": "0,2 Liter",
+                    "groupId": 5
+                }
+            ]
+        },
+        {
+            "number": "swTEST52b04c97dd28f",
+            "inStock": 100,
+            "unitId": 1,
+            "prices": [
+                {
+                    "customerGroupKey": "EK",
+                    "from": 1,
+                    "to": "-",
+                    "price": 400
+                }
+            ],
+            "configuratorOptions": [
+                {
+                    "option": "0,5 Liter",
+                    "groupId": 5
+                }
+            ]
+        }
+    ]
+}
 ```
 
 ### The following example creates two assignments for the passed image.
-* Show the image if the customer selects <code>"0,5 Liter"</code> and "Rot".
+* Show the image if the customer selects `"0,5 Liter"` and "Rot".
 * Show the image if the customer selects "Blau".
 
-```php
-array(
-    'name' => 'Testartikel',
-    'images' => array(
-        array(
-            'mediaId' => 236,
-            'options' => array(
-                array(
-                    array('name' => '0,5 Liter'),
-                    array('name' => 'rot')
-                ),
-                array(
-                    array('name' => 'blau')
-                )
-            ),
-        ),
-    ),
-    'configuratorSet' => array(
-        'name' => 'Test-Set',
-        'groups' => array(
-            array(
-                'id' => 5,
-                'name' => 'Flascheninhalt',
-                'options' => array(
-                    array('id' => 11,'name' => '0,2 Liter'),
-                    array('id' => 35,'name' => '0,5 Liter'),
-                    array('id' => 12,'name' => '0,7 Liter'),
-                    array('id' => 32,'name' => '1,0 Liter'),
-                ),
-            ),
-            array(
-                'id' => 6,
-                'name' => 'Farbe',
-                'options' => array(
-                    array('id' => 13,'name' => 'weiss'),
-                    array('id' => 14,'name' => 'schwarz'),
-                    array('id' => 15,'name' => 'blau'),
-                    array('id' => 28,'name' => 'rot'),
-                ),
-            ),
-        ),
-    ),
-    'variants' => array(...)
-);
+{% include 'api_badge.twig' with {'route': '/api/articles/1234', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "name": "Testartikel",
+    "images": [
+        {
+            "mediaId": 236,
+            "options": [
+                [
+                    {
+                        "name": "0,5 Liter"
+                    },
+                    {
+                        "name": "rot"
+                    }
+                ],
+                [
+                    {
+                        "name": "blau"
+                    }
+                ]
+            ]
+        }
+    ],
+    "configuratorSet": {
+        "name": "Test-Set",
+        "groups": [
+            {
+                "id": 5,
+                "name": "Flascheninhalt",
+                "options": [
+                    {
+                        "id": 11,
+                        "name": "0,2 Liter"
+                    },
+                    {
+                        "id": 35,
+                        "name": "0,5 Liter"
+                    },
+                    {
+                        "id": 12,
+                        "name": "0,7 Liter"
+                    },
+                    {
+                        "id": 32,
+                        "name": "1,0 Liter"
+                    }
+                ]
+            },
+            {
+                "id": 6,
+                "name": "Farbe",
+                "options": [
+                    {
+                        "id": 13,
+                        "name": "weiss"
+                    },
+                    {
+                        "id": 14,
+                        "name": "schwarz"
+                    },
+                    {
+                        "id": 15,
+                        "name": "blau"
+                    },
+                    {
+                        "id": 28,
+                        "name": "rot"
+                    }
+                ]
+            }
+        ]
+    },
+    "variants": [
+      {}
+    ]
+}
 ```
 
 ### Assignment
  
 The first level of the option array defines how many assignment are created. 
-You can define <code>AND / OR</code> assignment for each assignment.
+You can define `AND / OR` assignment for each assignment.
 
-```php
-'options' => array(    
-    array(
-        array('name' => '0,5 Liter'),
-        // AND
-        array('name' => 'rot')
-    ),
-    // OR
-    array(
-        array('name' => 'blau')
-    )
-)
+```json
+{
+    "configuratorSet": {
+        // ...
+        "groups": [
+            {
+            "options": [
+                    [
+                        {
+                            "name": "0,5 Liter"
+                        },
+                        // AND
+                        {
+                            "name": "rot"
+                        }
+                    ],
+                    // OR
+                    [
+                        {
+                            "name": "blau"
+                        }
+                    ]
+                ]
+            }
+        ]
+    }
+}
 ```
 
 ### optimize the API performance
 
-To optimize the API performance it is necessary to send a second API request to create the child data sets in <code>s_articles_img</code>.
+To optimize the API performance it is necessary to send a second API request to create the child data sets in `s_articles_img`.
 
-```php
-PUT /api/generateArticleImages/1
-PUT /api/generateArticleImages/SW-200?useNumberAsId=true
-```
+{% include 'api_badge.twig' with {'route': '/api/generateArticleImages/1', 'method': 'PUT'} %}
+
+{% include 'api_badge.twig' with {'route': '/api/generateArticleImages/SW-20001?useNumberAsId=true', 'method': 'PUT'} %}
+
 
 
 

--- a/source/developers-guide/rest-api/examples/merge-mode/index.md
+++ b/source/developers-guide/rest-api/examples/merge-mode/index.md
@@ -17,102 +17,130 @@ subgroup: REST API
 In this article, you will find examples of the provided resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[category API resource](/developers-guide/rest-api/api-resource-categories/)** if you haven't yet, to get more information about the category resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
-
 It is possible to change the default behavior of the API to process associated data.
 
 ## API merge Mode (Data merge)
 
-<b>Example situation:</b>
-* There exists a product with two images in the database. <code>Artikel-ID: 1</code> and <code>Bild-ID: 2, 3</code>
+**Example situation:**
+* There exists a product with two images in the database. `product-id: 1` and `image-id: [2, 3]`
 * The first example overwrites the images with two new images.
 * The second example adds two new images.
 
 ### Example request 1: (overwrite)
-```php
-// PUT /api/articles/1
-array(
-    '__options_images' => array('replace' => true),
-    'images' => array(
-        112 => array(
-            'mediaId' => 112,
-            'main' => 1,
-        ),
-        113 => array(
-            'mediaId' => 113,
-            'main' => '2',
-        )
-    ),
-);
+
+{% include 'api_badge.twig' with {'route': '/api/articles/1', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "__options_images": {
+        "replace": true
+    },
+    "images": {
+        "112": {
+            "mediaId": 112,
+            "main": 1
+        },
+        "113": {
+            "mediaId": 113,
+            "main": "2"
+        }
+    }
+}
 ```
 
 ### Example request 2: (Merge)
 
-```php
-// PUT /api/articles/1
-array(
-    '__options_images' => array('replace' => false),
-    'images' => array(
-        114 => array(
-            'mediaId' => 114,
-            'main' => 2,
-        ),
-        115 => array(
-            'mediaId' => 115,
-            'main' => '2',
-        )
-    ),
-);
+{% include 'api_badge.twig' with {'route': '/api/articles/1', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "__options_images": {
+        "replace": false
+    },
+    "images": {
+        "114": {
+            "mediaId": 114,
+            "main": 2
+        },
+        "115": {
+            "mediaId": 115,
+            "main": "2"
+        }
+    }
+}
 ```
 
-## The following collection implements the "merge mode"
+## Entities implementing the "merge mode"
 
-```php
-$articleData = array(
-    // default: replace
-    '__options_categories' => array('replace' => true),
-    'categories' => array(
-        array('id' => 13)
-    ),
-    // default: replace
-    '__options_related' => array('replace' => true),
-    'related' => array(
-        array('id' => 13)
-    ),
-    // default: replace
-    '__options_similar' => array('replace' => true),
-    'similar' => array(
-        array('id' => 13)
-    ),
-    // default: replace
-    '__options_downloads' => array('replace' => true),
-    'downloads' => array(
-        array('id' => 13)
-    ),
-    // default: replace
-    '__options_customerGroups' => array('replace' => true),
-    'customerGroups' => array(
-        array('id' => 13)
-    ),
-    // default: merge
-    '__options_images' => array('replace' => false),
-    'images' => array(
-        array('id' => 13)
-    ),
-    // default: replace
-    '__options_variants' => array('replace' => true),
-    'variants' => array(
-        array(
-            'id' => 13
-        )
-    ),
-    'mainDetail' => array(
-        // default: replace
-        '__options_prices' => array('replace' => true),
-        'prices' => array(
-             
-        )
-    )
-);
+The following list contains all entities implementing the merge mode.
+The replace value given here represents the default value which is used
+when no value for `replace` is given in the request body.
+
+A default value of `replace: true` means, that the existing entity should
+be overwritten, `replace: false` means, that the existing entities should
+be merged with the new ones provided in the API-request.
+
+```json
+{
+    "__options_categories": {
+        "replace": true
+    },
+    "categories": [
+        {
+            "id": 13
+        }
+    ],
+    "__options_related": {
+        "replace": true
+    },
+    "related": [
+        {
+            "id": 13
+        }
+    ],
+    "__options_similar": {
+        "replace": true
+    },
+    "similar": [
+        {
+            "id": 13
+        }
+    ],
+    "__options_downloads": {
+        "replace": true
+    },
+    "downloads": [
+        {
+            "id": 13
+        }
+    ],
+    "__options_customerGroups": {
+        "replace": true
+    },
+    "customerGroups": [
+        {
+            "id": 13
+        }
+    ],
+    "__options_images": {
+        "replace": false
+    },
+    "images": [
+        {
+            "id": 13
+        }
+    ],
+    "__options_variants": {
+        "replace": true
+    },
+    "variants": [
+        {
+            "id": 13
+        }
+    ],
+    "mainDetail": {
+        "__options_prices": {
+            "replace": true
+        },
+        "prices": []
+    }
+}
 ```

--- a/source/developers-guide/rest-api/examples/order/index.md
+++ b/source/developers-guide/rest-api/examples/order/index.md
@@ -16,18 +16,16 @@ subgroup: REST API
 In this article you can read more about using the orders resource.
 The following part will show you examples including provided data and data you need to provide if you want to use this resource.
 Please read **[Orders](/developers-guide/rest-api/api-resource-orders/)** if you did not yet, to get more information about the orders resource and the data it provides.
-Also we are using the API client of the following document **[API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
 
 ## Example 1 - Load all orders
 This example shows you how to get all orders of the shop. You may also limit the result count by providing a limit parameter.
 
-```
-$client->get('orders');
-$client->get('orders?limit=20'); //Will only get 20 orders
-```
+{% include 'api_badge.twig' with {'route': '/api/orders', 'method': 'GET'} %}
+
+{% include 'api_badge.twig' with {'route': '/api/orders?limit=20', 'method': 'GET'} %}
 
 ### Result
-```
+```json
 {
    "data":[
       {
@@ -160,14 +158,13 @@ $client->get('orders?limit=20'); //Will only get 20 orders
 
 To load a specific order, you have to provide either the identifier or the number of the order.
 
-```
-$client->get('orders/15');
-$client->get('orders/2002?useNumberAsId=true');
-```
+{% include 'api_badge.twig' with {'route': '/api/orders/15', 'method': 'GET'} %}
+
+{% include 'api_badge.twig' with {'route': '/api/orders/2002?useNumberAsId=true', 'method': 'GET'} %}
 
 ### Result
 
-```
+```json
 {
    "data":{
       "id":15,
@@ -548,39 +545,35 @@ $client->get('orders/2002?useNumberAsId=true');
 ## Example 3 - Update an order
 **Currently, it's only possible to update the following fields of an order:**
 
-```
-paymentStatusId
-orderStatusId
-trackingCode
-comment
-transactionId
-clearedDate
-```
+- `paymentStatusId`
+- `orderStatusId`
+- `trackingCode`
+- `comment`
+- `transactionId`
+- `clearedDate`
 
-This example shows you how to update those fields:
-```
-$date = new DateTime();
-$date->modify('+10 days');
-$date = $date->format(DateTime::ISO8601);
+This example shows you how to update those fields, dates should be
+encoded according to the **[ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)** standard:
 
-$client->put('orders/15',  array(
-    'paymentStatusId' => 10,
-    'orderStatusId' => 8,
-    'trackingCode' => '237948723894789234',
-    'comment' => 'Neuer Kommentar',
-    'transactionId' => '0',
-    'clearedDate' => $date
-));
+{% include 'api_badge.twig' with {'route': '/api/orders/15', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "paymentStatusId": 10,
+    "orderStatusId": 8,
+    "trackingCode": "237948723894789234",
+    "comment": "Neuer Kommentar",
+    "transactionId": "0",
+    "clearedDate": "2019-10-18T17:58:17+0000"
+}
 ```
 
 ### Result
 
-```
-(
-    [id] => 2
-    [location] => http://www.yourdomain.com/api/orders/2
-)
-
+```json
+{
+  "id": 2,
+  "location": "https://shop.example.com/api/orders/2"
+}
 ```
 
 ## Example 4 - Creating an order
@@ -591,152 +584,142 @@ This example shows you how to create an order. Currently all referenced entities
 
 If some field is missing from the request or some id provided does not exist, an exception is returned accordingly.
 
-```
-$client->post('orders', [
-    "customerId" => 1,
-    "paymentId" => 4,
-    "dispatchId" => 9,
-    "partnerId" => "",
-    "shopId" => 1,
-    "invoiceAmount" => 201.86,
-    "invoiceAmountNet" => 169.63,
-    "invoiceShipping" => 0,
-    "invoiceShippingNet" => 0,
-    "orderTime" => "2012-08-31 08:51:46",
-    "net" => 0,
-    "taxFree" => 0,
-    "languageIso" => "1",
-    "currency" => "EUR",
-    "currencyFactor" => 1,
-    "remoteAddress" => "217.86.205.141",
-    "details" => [[
-        "articleId" => 220,
-        "taxId" => 1,
-        "taxRate" => 19,
-        "statusId" => 0,
-        "articleNumber" => "SW10001",
-        "price" => 35.99,
-        "quantity" => 1,
-        "articleName" => "Versandkostenfreier Artikel",
-        "shipped" => 0,
-        "shippedGroup" => 0,
-        "mode" => 0,
-        "esdArticle" => 0,
-    ], [
-        "articleId" => 219,
-        "taxId" => 1,
-        "taxRate" => 19,
-        "statusId" => 0,
-        "articleNumber" => "SW10185",
-        "price" => 54.9,
-        "quantity" => 1,
-        "articleName" => "Express Versand",
-        "shipped" => 0,
-        "shippedGroup" => 0,
-        "mode" => 0,
-        "esdArticle" => 0,
-    ], [
-        "articleId" => 197,
-        "taxId" => 1,
-        "taxRate" => 19,
-        "statusId" => 0,
-        "articleNumber" => "SW10196",
-        "price" => 34.99,
-        "quantity" => 2,
-        "articleName" => "ESD Download Artikel",
-        "shipped" => 0,
-        "shippedGroup" => 0,
-        "mode" => 0,
-        "esdArticle" => 1,
-    ]],
-    "documents" => [],
-    "billing" => [
-        "id" => 2,
-        "customerId" => 1,
-        "countryId" => 2,
-        "stateId" => 3,
-        "company" => "shopware AG",
-        "salutation" => "mr",
-        "firstName" => "Max",
-        "lastName" => "Mustermann",
-        "street" => "Mustermannstra\u00dfe 92",
-        "zipCode" => "48624",
-        "city" => "Sch\u00f6ppingen",
+{% include 'api_badge.twig' with {'route': '/api/orders', 'method': 'POST', 'body': true} %}
+```json
+{
+    "customerId": 1,
+    "paymentId": 4,
+    "dispatchId": 9,
+    "partnerId": "",
+    "shopId": 1,
+    "invoiceAmount": 201.86,
+    "invoiceAmountNet": 169.63,
+    "invoiceShipping": 0,
+    "invoiceShippingNet": 0,
+    "orderTime": "2012-08-31 08:51:46",
+    "net": 0,
+    "taxFree": 0,
+    "languageIso": "1",
+    "currency": "EUR",
+    "currencyFactor": 1,
+    "remoteAddress": "217.86.205.141",
+    "details": [
+        {
+            "articleId": 220,
+            "taxId": 1,
+            "taxRate": 19,
+            "statusId": 0,
+            "articleNumber": "SW10001",
+            "price": 35.99,
+            "quantity": 1,
+            "articleName": "Versandkostenfreier Artikel",
+            "shipped": 0,
+            "shippedGroup": 0,
+            "mode": 0,
+            "esdArticle": 0
+        },
+        {
+            "articleId": 219,
+            "taxId": 1,
+            "taxRate": 19,
+            "statusId": 0,
+            "articleNumber": "SW10185",
+            "price": 54.9,
+            "quantity": 1,
+            "articleName": "Express Versand",
+            "shipped": 0,
+            "shippedGroup": 0,
+            "mode": 0,
+            "esdArticle": 0
+        },
+        {
+            "articleId": 197,
+            "taxId": 1,
+            "taxRate": 19,
+            "statusId": 0,
+            "articleNumber": "SW10196",
+            "price": 34.99,
+            "quantity": 2,
+            "articleName": "ESD Download Artikel",
+            "shipped": 0,
+            "shippedGroup": 0,
+            "mode": 0,
+            "esdArticle": 1
+        }
     ],
-    "shipping" => [
-        "id" => 2,
-        "countryId" => 2,
-        "stateId" => 3,
-        "customerId" => 1,
-        "company" => "shopware AG",
-        "salutation" => "mr",
-        "firstName" => "Max",
-        "lastName" => "Mustermann",
-        "street" => "Mustermannstra\u00dfe 92",
-        "zipCode" => "48624",
-        "city" => "Sch\u00f6ppingen"
-    ],
-    "paymentStatusId" => 17,
-    "orderStatusId" => 0
-]);
+    "documents": [],
+    "billing": {
+        "id": 2,
+        "customerId": 1,
+        "countryId": 2,
+        "stateId": 3,
+        "company": "shopware AG",
+        "salutation": "mr",
+        "firstName": "Max",
+        "lastName": "Mustermann",
+        "street": "Mustermannstra\\u00dfe 92",
+        "zipCode": "48624",
+        "city": "Sch\\u00f6ppingen"
+    },
+    "shipping": {
+        "id": 2,
+        "countryId": 2,
+        "stateId": 3,
+        "customerId": 1,
+        "company": "shopware AG",
+        "salutation": "mr",
+        "firstName": "Max",
+        "lastName": "Mustermann",
+        "street": "Mustermannstra\\u00dfe 92",
+        "zipCode": "48624",
+        "city": "Sch\\u00f6ppingen"
+    },
+    "paymentStatusId": 17,
+    "orderStatusId": 0
+}
 ```
 
 ### Result
 
-```
-(
-    [id] => 60
-    [location] => http://www.yourdomain.com/api/orders/60
-)
+```json
+{
+  "id": 60,
+  "location": "https://shop.example.com/api/orders/60"
+}
 ```
 
 ## Further examples
 
+### Filter by `paymentStatusId`
+
+{% include 'api_badge.twig' with {'route': '/api/orders?filter[cleared]=0', 'method': 'GET'} %}
+
+### Filter by `orderStatusId`
+
+{% include 'api_badge.twig' with {'route': '/api/orders?filter[status]=0', 'method': 'GET'} %}
+
+### Filter by `clearedDate`
+
+{% include 'api_badge.twig' with {'route': '/api/orders?filter[0][property]=clearedDate&filter[0][expression]=>=&filter[0][value]=2012-10-14', 'method': 'GET'} %}
+
+### Change status
+
+{% include 'api_badge.twig' with {'route': '/api/orders/1', 'method': 'PUT', 'body': true} %}
+```json
+{
+  "paymentStatusId": 12,
+  "clearedDate": "2012-10-17"
+}
 ```
-// filter by paymentStatusId
-$filterByPaymentStatus = array(
-    array(
-        'property' => 'cleared',
-        'value'    => 0
-    ),
-);
 
-// filter by orderStatusId
-$filterByOrderStatus = array(
-    array(
-        'property' => 'status',
-        'value'    => 0
-    ),
-);
+### Change status using the `orderNumber` as identifier
 
-// filter by clearedDate
-$filterByClearedDate = array(
-    array(
-        'property' => 'clearedDate',
-        'expression' => '>=',
-        'value'    => '2012-10-14'
-    ),
-);
-
-$params = array(
-    'filter' => $filterByPaymentStatus
-);
-
-$client->get('orders', $params);
-
-
-// Change status
-$updateOrder = array(
-    'paymentStatusId' => 12,
-    'clearedDate' => '2012-10-17',
-);
-
-//Using ordernumber as identifier
-$params = array(
-    'useNumberAsId' => true
-);
-
-$client->put('orders/20001', $updateOrder, $params);
+{% include 'api_badge.twig' with {'route': '/api/orders/20001?useNumberAsId=true', 'method': 'PUT', 'body': true} %}
+```json
+{
+  "paymentStatusId": 12,
+  "clearedDate": "2012-10-17"
+}
 ```
 
 **[Back to overview](../#examples)**

--- a/source/developers-guide/rest-api/examples/payment/index.md
+++ b/source/developers-guide/rest-api/examples/payment/index.md
@@ -15,30 +15,28 @@ subgroup: REST API
 In this article, you will find examples of the provided resource usage for different operations. For each analyzed scenario, we provide an example of the data that you are expected to provide to the API, as well as an example response.
 Please read the page covering the **[category API resource](/developers-guide/rest-api/api-resource-categories/)** if you haven't yet, to get more information about the category resource and the data it provides.
 
-These examples assume you are using the provided **[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
-
 ## Usage
 
-The Rest API calls for customer data ('''/api/customers''' und '''/api/customers/{id}''') supports payment information.
+The Rest API calls for customer data (`/api/customers` and `/api/customers/{id}`) support payment information.
 This means you can list, create or update the payment data for customers.
 
-Calls for order details ('''/api/orders/{id}''') covers the payment instances.
+Calls for order details (`/api/orders/{id}`) covers the payment instances.
 This contains the information about the payment and orders.
 This field could not be changed. Creating or updating are not supported.
 
-<b>Example:</b>
+**Example:**
 
-```php
-// PUT /api/customers/1
-array(
-    "paymentData" => array(
-        array(
-            "paymentMeanId"   => 2,
-            "accountNumber" => "Account",
-            "bankCode"      => "55555555",
-            "bankName"      => "Bank",
-            "accountHolder" => "Max Mustermann",
-        ),
-    ),
-);
+{% include 'api_badge.twig' with {'route': '/api/customers/1', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "paymentData": [
+        {
+            "paymentMeanId": 2,
+            "accountNumber": "Account",
+            "bankCode": "55555555",
+            "bankName": "Bank",
+            "accountHolder": "Max Mustermann"
+        }
+    ]
+}
 ```

--- a/source/developers-guide/rest-api/examples/translation/index.md
+++ b/source/developers-guide/rest-api/examples/translation/index.md
@@ -15,146 +15,139 @@ subgroup: REST API
 In this article you can read more about using the translation resource.
 The following part will show you examples including provided data and data you need to provide if you want to use this resource.
 Please read **[Translation](/developers-guide/rest-api/api-resource-translation/)** if you did not yet, to get more information about the translation resource and the data it provides.
-Also we are using the API client of the following document **[API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**.
 
 ## Example 1 - Creating a new translation
 
 This example shows how to create a new article translation
 
-```php
-<?php
-$api->post('translations', [
-        'key' => 200,            #  s_articles.id
-        'type' => 'article',
-        'shopId' => 2,           # s_core_shops.id
-        'data' => [
-                'name' => 'Dummy translation',
-                '__attribute_attr1' => 'Dummy attribute translation'
-        ...
-    ]
-]);
-
+{% include 'api_badge.twig' with {'route': '/api/translations', 'method': 'POST', 'body': true} %}
+```json
+{
+    "key": 200,
+    "type": "article",
+    "shopId": 2,
+    "data": {
+        "name": "Dummy translation",
+        "__attribute_attr1": "Dummy attribute translation"
+    }
+}
 ```
 
 ## Example 2 - Updating a translation
 
-```php
-<?php
-$client->put('translations/200', [ #  s_articles.id
-        'type' => 'article',
-        'shopId' => 2,             # s_core_shops.id
-        'data' => [
-                'name' => 'Dummy translation',
-                '__attribute_attr1' => 'Dummy attribute translation'
-        ...
-    ]
-]);
-
+{% include 'api_badge.twig' with {'route': '/api/translations/200', 'method': 'PUT', 'body': true} %}
+```json
+{
+    "type": "article",
+    "shopId": 2,
+    "data": {
+        "name": "Dummy translation",
+        "__attribute_attr1": "Dummy attribute translation"
+    }
+}
 ```
 
 ## Example 3 - Creating a property group translation
 
-```php
-<?php
-$api->post('translations', [
-        'key' => 6,             # s_filter.id
-        'type' => 'propertygroup',
-        'shopId' => 2,          # s_core_shops.id
-        'data' => [
-            'groupName' => 'Dummy translation',
-        ]
-]);
+{% include 'api_badge.twig' with {'route': '/api/translations', 'method': 'POST', 'body': true} %}
+```json
+{
+    "key": 6,
+    "type": "propertygroup",
+    "shopId": 2,
+    "data": {
+        "groupName": "Dummy translation"
+    }
+}
 ```
 
 ## Example 4 - Updating a property group translation
 
-```php
-<?php
-$api->post('translations/6', [  # s_filter.id
-        'type' => 'propertygroup',
-        'shopId' => 2,          # s_core_shops.id
-        'data' => [
-            'groupName' => 'Dummy translation edited',
-        ]
-]);
+{% include 'api_badge.twig' with {'route': '/api/translations/6', 'method': 'POST', 'body': true} %}
+```json
+{
+    "type": "propertygroup",
+    "shopId": 2,
+    "data": {
+        "groupName": "Dummy translation edited"
+    }
+}
 ```
 
 ## Example 5 - Creating a property option translation
 
-```php
-<?php
-$api->post('translations', [
-        'key' => 1,          # s_filter_options.id
-        'type' => 'propertyoption',
-        'shopId' => 2,       # s_core_shops.id
-        'data' => [
-            'optionName' => 'Dummy translation',
-        ]
-]);
+{% include 'api_badge.twig' with {'route': '/api/translations', 'method': 'POST', 'body': true} %}
+```json
+{
+    "key": 1,
+    "type": "propertyoption",
+    "shopId": 2,
+    "data": {
+        "optionName": "Dummy translation"
+    }
+}
 ```
 
 ## Example 6 - Updating a property option translation
 
-```php
-<?php
-$api->post('translations/1', [  # s_filter_options.id
-        'type' => 'propertyoption',
-        'shopId' => 2,          # s_core_shops.id
-        'data' => [
-            'optionName' => 'Dummy translation edited',
-        ]
-]);
+{% include 'api_badge.twig' with {'route': '/api/translations/1', 'method': 'POST', 'body': true} %}
+```json
+{
+    "type": "propertyoption",
+    "shopId": 2,
+    "data": {
+        "optionName": "Dummy translation edited"
+    }
+}
 ```
 
 ## Example 7 - Creating a property value translation
 
-```php
-<?php
-$api->post('translations', [
-        'key' => 166,          # s_filter_values.id
-        'type' => 'propertyvalue',
-        'shopId' => 2,         # s_core_shops.id
-        'data' => [
-            'optionValue' => 'Dummy translation',
-        ]
-]);
+{% include 'api_badge.twig' with {'route': '/api/translations', 'method': 'POST', 'body': true} %}
+```json
+{
+    "key": 166,
+    "type": "propertyvalue",
+    "shopId": 2,
+    "data": {
+        "optionValue": "Dummy translation"
+    }
+}
 ```
 
 ## Example 8 - Updating a property value translation
 
-```php
-<?php
-$api->post('translations/166', [ # s_filter_values.id
-        'type' => 'propertyvalue',
-        'shopId' => 2,           # s_core_shops.id
-        'data' => [
-            'optionValue' => 'Dummy translation edited',
-        ]
-]);
+{% include 'api_badge.twig' with {'route': '/api/translations/166', 'method': 'POST', 'body': true} %}
+```json
+{
+    "type": "propertyvalue",
+    "shopId": 2,
+    "data": {
+        "optionValue": "Dummy translation edited"
+    }
+}
 ```
-
 
 ## Example 9 - Updating multiple translations (batch mode)
 
-```php
-<?php
-$api->put('translations', [
-    [
-        'key' => 177, # s_filter_values.id
-        'type' => 'propertyvalue',
-        'shopId' => 2,           # s_core_shops.id
-        'data' => [
-            'optionValue' => 'Dummy translation edited',
-        ]
-    ],
-    [
-        'key' => 178, # s_filter_values.id
-        'type' => 'propertyvalue',
-        'shopId' => 2,           # s_core_shops.id
-        'data' => [
-            'optionValue' => 'Another dummy translation edited',
-        ]
-    ],
-      
-]);
+{% include 'api_badge.twig' with {'route': '/api/translations', 'method': 'PUT', 'body': true} %}
+```json
+[
+    {
+        "key": 177,
+        "type": "propertyvalue",
+        "shopId": 2,
+        "data": {
+            "optionValue": "Dummy translation edited"
+        }
+    },
+    {
+        "key": 178,
+        "type": "propertyvalue",
+        "shopId": 2,
+        "data": {
+            "optionValue": "Another dummy translation edited"
+        }
+    }
+]
 ```

--- a/source/developers-guide/rest-api/plugin-api-extension/index.md
+++ b/source/developers-guide/rest-api/plugin-api-extension/index.md
@@ -409,17 +409,10 @@ This resource supports the following operations:
 If you want to access this resource, simply query the following URL:
 * http://my-shop-url/api/banner
 
-The following examples assume you are using the provided
-**[demo API client](/developers-guide/rest-api/#using-the-rest-api-in-your-own-application)**. One of its advantages is that, 
-instead of providing query arguments directly in the URL, you can do so by means of method argument.
-The client application will, internally, handle the full URL generation. You can also place variables using
-this technique.
-
 ### GET
 Getting one banner by its id.
-```php
-$client->get('banner/1');
-```
+
+{% include 'api_badge.twig' with {'route': '/api/banner/1', 'method': 'GET'} %}
 
 Result:
 ```json
@@ -442,9 +435,8 @@ Result:
 ### GET(List)
 Get a list of banners. With the optional `limit` parameter, it is possible to specify how many banner you want the 
 API to return.
-```php
-$client->get('banner');
-```
+
+{% include 'api_badge.twig' with {'route': '/api/banner', 'method': 'GET'} %}
 
 Result
 ```json
@@ -494,10 +486,12 @@ Result
 ### PUT
 To update a banner it is always required to provide the id of the banner. In this example, we will update the 
 `description` of the banner with id 1.
-```php
-$client->put('banner/1', [
-   'description' => 'New description'
-]);
+
+{% include 'api_badge.twig' with {'route': '/api/banner/1', 'method': 'PUT', 'body': true} %}
+```json
+{
+  "description": "New description"
+}
 ```
 
 Result:
@@ -514,14 +508,15 @@ Result:
 ### POST
 Create a new banner
 
-```php
-$client->post('banner', [
-    'description' => 'Shopware-Example-Banner1',
-    'image' => 'media/image/41/f8/25/Blog-Koffer.jpg',
-    'link' => 'www.shopware.com',
-    'linkTarget' => '_blank',
-    'categoryId' => '3',
-]);
+{% include 'api_badge.twig' with {'route': '/api/banner', 'method': 'POST', 'body': true} %}
+```json
+{
+    "description": "Shopware-Example-Banner1",
+    "image": "media\/image\/41\/f8\/25\/Blog-Koffer.jpg",
+    "link": "www.shopware.com",
+    "linkTarget": "_blank",
+    "categoryId": "3"
+}
 ```
 
 Result:
@@ -538,9 +533,7 @@ Result:
 ### DELETE
 Delete one banner identified by its id. In this case we delete the banner with id 1.
 
-```php
-$client->delete('banner/1');
-```
+{% include 'api_badge.twig' with {'route': '/api/banner/1', 'method': 'DELETE'} %}
 
 Result:
 ```json


### PR DESCRIPTION
Like described in the title - I rewrote all examples from using the example-client written in PHP to JSON. This means the examples can now be copied and executed with any HTTP-Client.

Instead of showing the method to be used via function calls `$client->post()`, they're now displayed using a colour-coded badge.

There are two issues still left to be discussed I think:
1. Should the example client still be documented? (I left it as it is)
2. There are a few pages which show `GET` requests [with request-bodies](https://developers.shopware.com/developers-guide/rest-api/customer-streams/#get-information-about-an-existing-stream) and I didn't rewrite those, as I think they rely on non-standard behaviour. Should these examples be kept or deleted?