### PR TITLE
SW-25273 - Add a link to the Shopware 6 documentation

### DIFF
--- a/source/_layouts/default.twig.html
+++ b/source/_layouts/default.twig.html
@@ -70,41 +70,62 @@
     <nav class="navi--main" data-offcanvas="true">
         <div class="navi--content">
             <ul class="navi--tree">
-                {% for group in page.menu %}
-
-                <li class="navi--chapter{% if (page.group == group.menu_title) or (page.menu_title == group.menu_title) %} is--active{% endif %}">
-                    <a href="{{ group.url }}" class="navi--link{% if (page.group == group.menu_title) or (page.menu_title == group.menu_title) %} is--active{% endif %}{% if group.children %} has--children{% endif %}">
-                       {{ group.menu_title }}
+                <li class="navi--chapter is--active">
+                    <a href="/" class="navi--link has--children">
+                        Shopware 5
                     </a>
+                    <ul class="navi--sub-1-tree">
+                        {% for group in page.menu %}
 
-                    {% if group.children %}
-                    <ul class="navi--sub-tree{% if group.menu_style == 'numeric' %} is--numbered{% endif %}{% if group.menu_style == 'bullet' %} is--bulleted{% endif %}">
-                        {% for subgroup in group.children %}
-                        <li class="navi--sub-chapter{% if ((page.subgroup == subgroup.menu_title) and (page.group == group.menu_title)) or (page.menu_title == subgroup.menu_title) %} is--active{% endif %}">
-
-                            <a class="navi--link{% if page.subgroup == subgroup.menu_title or (page.menu_title == subgroup.menu_title) %} is--active{% endif %}{% if subgroup.children %} has--children{% endif %}" href="{{ subgroup.url }}">
-                                {{ subgroup.menu_title }}
+                        <li class="navi--sub-1-chapter{% if (page.group == group.menu_title) or (page.menu_title == group.menu_title) %} is--active{% endif %}">
+                            <a href="{{ group.url }}" class="navi--link{% if (page.group == group.menu_title) or (page.menu_title == group.menu_title) %} is--active{% endif %}{% if group.children %} has--children{% endif %}">
+                                {{ group.menu_title }}
                             </a>
 
-                            {% if subgroup.children %}
-                                <ul class="navi--sub-tree{% if subgroup.menu_style == 'numeric' %} is--numbered{% endif %}{% if subgroup.menu_style == 'bullet' %} is--bulleted{% endif %}">
+                            {% if group.children %}
+                            <ul class="navi--sub-2-tree{% if group.menu_style == 'numeric' %} is--numbered{% endif %}{% if group.menu_style == 'bullet' %} is--bulleted{% endif %}">
+                                {% for subgroup in group.children %}
+                                <li class="navi--sub-2-chapter{% if ((page.subgroup == subgroup.menu_title) and (page.group == group.menu_title)) or (page.menu_title == subgroup.menu_title) %} is--active{% endif %}">
 
-                                    {% for item in subgroup.children %}
-                                        <li class="navi--sub-chapter">
+                                    <a class="navi--link{% if page.subgroup == subgroup.menu_title or (page.menu_title == subgroup.menu_title) %} is--active{% endif %}{% if subgroup.children %} has--children{% endif %}" href="{{ subgroup.url }}">
+                                        {{ subgroup.menu_title }}
+                                    </a>
+
+                                    {% if subgroup.children %}
+                                    <ul class="navi--sub-3-tree{% if subgroup.menu_style == 'numeric' %} is--numbered{% endif %}{% if subgroup.menu_style == 'bullet' %} is--bulleted{% endif %}">
+
+                                        {% for item in subgroup.children %}
+                                        <li class="navi--sub-3-chapter">
                                             <a class="navi--link{% if page.menu_title == item.menu_title %} is--active{% endif %}" href="{{ item.url }}">
                                                 {{ item.menu_title }}
                                             </a>
                                         </li>
-                                    {% endfor %}
-                                </ul>
+                                        {% endfor %}
+                                    </ul>
+                                    {% endif %}
+                                </li>
+                                {% endfor %}
+                            </ul>
                             {% endif %}
                         </li>
+
                         {% endfor %}
                     </ul>
-                    {% endif %}
                 </li>
-
-                {% endfor %}
+            </ul>
+            <ul class="navi--tree">
+                <li class="navi--chapter">
+                    <a href="https://docs.shopware.com/en/shopware-platform-dev-en" class="navi--link">
+                        <span>
+                            Shopware 6
+                        </span>
+                        <span>
+                            <i class="icon-external-link"></i>
+                        </span>
+                    </a>
+                </li>
+            </ul>
+            <ul class="navi--tree">
                 <li class="navi--chapter navi--backlink-mobile">
                     <a href="https://en.shopware.com" class="navi--link"><i class="icon--arrow-left"></i> Back to shopware.com</a>
                 </li>

--- a/source/_layouts/start.twig.html
+++ b/source/_layouts/start.twig.html
@@ -68,41 +68,62 @@
     <nav class="navi--main" data-offcanvas="true">
         <div class="navi--content">
             <ul class="navi--tree">
-                {% for group in page.menu %}
-
-                <li class="navi--chapter{% if (page.group == group.menu_title) or (page.menu_title == group.menu_title) %} is--active{% endif %}">
-                    <a href="{{ group.url }}" class="navi--link{% if (page.group == group.menu_title) or (page.menu_title == group.menu_title) %} is--active{% endif %}{% if group.children %} has--children{% endif %}">
-                        {{ group.menu_title }}
+                <li class="navi--chapter is--active">
+                    <a href="/" class="navi--link has--children">
+                        Shopware 5
                     </a>
+                    <ul class="navi--sub-1-tree">
+                        {% for group in page.menu %}
 
-                    {% if group.children %}
-                    <ul class="navi--sub-tree{% if group.menu_style == 'numeric' %} is--numbered{% endif %}{% if group.menu_style == 'bullet' %} is--bulleted{% endif %}">
-                        {% for subgroup in group.children %}
-                        <li class="navi--sub-chapter{% if ((page.subgroup == subgroup.menu_title) and (page.group == group.menu_title)) or (page.menu_title == subgroup.menu_title) %} is--active{% endif %}">
-
-                            <a class="navi--link{% if page.subgroup == subgroup.menu_title or (page.menu_title == subgroup.menu_title) %} is--active{% endif %}{% if subgroup.children %} has--children{% endif %}" href="{{ subgroup.url }}">
-                                {{ subgroup.menu_title }}
+                        <li class="navi--sub-1-chapter{% if (page.group == group.menu_title) or (page.menu_title == group.menu_title) %} is--active{% endif %}">
+                            <a href="{{ group.url }}" class="navi--link{% if (page.group == group.menu_title) or (page.menu_title == group.menu_title) %} is--active{% endif %}{% if group.children %} has--children{% endif %}">
+                                {{ group.menu_title }}
                             </a>
 
-                            {% if subgroup.children %}
-                            <ul class="navi--sub-tree{% if subgroup.menu_style == 'numeric' %} is--numbered{% endif %}{% if subgroup.menu_style == 'bullet' %} is--bulleted{% endif %}">
+                            {% if group.children %}
+                            <ul class="navi--sub-2-tree{% if group.menu_style == 'numeric' %} is--numbered{% endif %}{% if group.menu_style == 'bullet' %} is--bulleted{% endif %}">
+                                {% for subgroup in group.children %}
+                                <li class="navi--sub-2-chapter{% if ((page.subgroup == subgroup.menu_title) and (page.group == group.menu_title)) or (page.menu_title == subgroup.menu_title) %} is--active{% endif %}">
 
-                                {% for item in subgroup.children %}
-                                <li class="navi--sub-chapter">
-                                    <a class="navi--link{% if page.menu_title == item.menu_title %} is--active{% endif %}" href="{{ item.url }}">
-                                        {{ item.menu_title }}
+                                    <a class="navi--link{% if page.subgroup == subgroup.menu_title or (page.menu_title == subgroup.menu_title) %} is--active{% endif %}{% if subgroup.children %} has--children{% endif %}" href="{{ subgroup.url }}">
+                                        {{ subgroup.menu_title }}
                                     </a>
+
+                                    {% if subgroup.children %}
+                                    <ul class="navi--sub-3-tree{% if subgroup.menu_style == 'numeric' %} is--numbered{% endif %}{% if subgroup.menu_style == 'bullet' %} is--bulleted{% endif %}">
+
+                                        {% for item in subgroup.children %}
+                                        <li class="navi--sub-3-chapter">
+                                            <a class="navi--link{% if page.menu_title == item.menu_title %} is--active{% endif %}" href="{{ item.url }}">
+                                                {{ item.menu_title }}
+                                            </a>
+                                        </li>
+                                        {% endfor %}
+                                    </ul>
+                                    {% endif %}
                                 </li>
                                 {% endfor %}
                             </ul>
                             {% endif %}
                         </li>
+
                         {% endfor %}
                     </ul>
-                    {% endif %}
                 </li>
-
-                {% endfor %}
+            </ul>
+            <ul class="navi--tree">
+                <li class="navi--chapter">
+                    <a href="https://docs.shopware.com/en/shopware-platform-dev-en" class="navi--link">
+                        <span>
+                            Shopware 6
+                        </span>
+                        <span>
+                            <i class="icon-external-link"></i>
+                        </span>
+                    </a>
+                </li>
+            </ul>
+            <ul class="navi--tree">
                 <li class="navi--chapter navi--backlink-mobile">
                     <a href="https://en.shopware.com" class="navi--link"><i class="icon--arrow-left"></i> Back to shopware.com</a>
                 </li>

--- a/source/assets/css/basic.less
+++ b/source/assets/css/basic.less
@@ -264,6 +264,11 @@ nav.navi--main:after {
 
             &.is--active {
                 padding-bottom: 10px;
+
+                ul.navi--sub-1-tree {
+                    height: auto;
+                    border: none;
+                }
             }
 
             .navi--link {
@@ -272,7 +277,7 @@ nav.navi--main:after {
                 color: rgba(255, 255, 255, 0.95);
                 font-weight: 500;
                 position: relative;
-                font-size: 17px;
+                font-size: 1.2rem;
                 z-index: 10;
                 border-left: 3px solid rgba(255, 255, 255, 0);
                 background-color: rgba(255, 255, 255, 0);
@@ -293,16 +298,15 @@ nav.navi--main:after {
                     border-left: 3px solid rgba(255, 255, 255, 1);
                     font-weight: 600;
                 }
+
+                .icon-external-link {
+                    margin: 0.2rem 0 0 0;
+                    float: right;
+                    opacity: 0.75;
+                }
             }
 
-            &.is--active {
-                ul.navi--sub-tree {
-                    height: auto;
-                    border: none;
-                 }
-            }
-
-            ul.navi--sub-tree {
+            ul.navi--sub-1-tree {
                 .transition(all 0.4s ease-out);
                 height: 0;
                 overflow: hidden;
@@ -311,11 +315,11 @@ nav.navi--main:after {
                     margin-bottom: 5px;
                 }
 
-                li.navi--sub-chapter {
+                li.navi--sub-1-chapter {
                     .navi--link {
-                        font-size: 16px;
+                        font-size: 1rem;
                         color: rgba(255, 255, 255, 0.55);
-                        padding: 5px 15px 5px 38px;
+                        padding: 5px 15px 5px 50px;
                         font-weight: 500;
                         z-index: 5;
 
@@ -348,17 +352,17 @@ nav.navi--main:after {
                     }
 
                     &.is--active {
-                        ul.navi--sub-tree {
+                        ul.navi--sub-2-tree {
                             height: auto;
                         }
                     }
 
-                    ul.navi--sub-tree {
+                    ul.navi--sub-1-tree, ul.navi--sub-2-tree, ul.navi--sub-3-tree {
                         .transition(all 0.4s ease-out);
                         height: 0;
                         overflow: hidden;
 
-                        li.navi--sub-chapter {
+                        li.navi--sub-1-chapter {
                             .navi--link {
                                 font-size: 15px;
                                 color: rgba(255, 255, 255, 0.33);
@@ -388,7 +392,7 @@ nav.navi--main:after {
                             }
                         }
 
-                        &.is--numbered li.navi--sub-chapter .navi--link {
+                        &.is--numbered li.navi--sub-1-chapter .navi--link {
                             &:before {
                                 display: block;
                                 width: 20px;
@@ -405,6 +409,31 @@ nav.navi--main:after {
 
                             }
                         }
+                    }
+                }
+            }
+
+            ul.navi--sub-2-tree {
+                li.navi--sub-2-chapter {
+
+                    &.is--active {
+                        ul.navi--sub-3-tree {
+                            height: auto;
+                        }
+                    }
+
+                    .navi--link {
+                        font-size: 1rem;
+                        padding-left: 62px;
+                    }
+                }
+            }
+
+            ul.navi--sub-3-tree {
+                li.navi--sub-3-chapter {
+                    .navi--link {
+                        font-size: 1rem;
+                        padding-left: 74px;
                     }
                 }
             }


### PR DESCRIPTION
This change restructures the left side menu, so that all existing links are bundled under a `Shopware 5` section (open by default). Another section `Shopware 6` with a corresponding link is added as well.