### PR TITLE
Fix broken SwagController example plugin

### DIFF
--- a/exampleplugins/5.2/SwagController/Resources/services.xml
+++ b/exampleplugins/5.2/SwagController/Resources/services.xml
@@ -3,7 +3,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="swag_controller.subscriber.load_templates" class="SwagProductListing\Subscriber\TemplateRegistration">
+        <service id="swag_controller.subscriber.load_templates" class="SwagController\Subscriber\TemplateRegistration">
             <argument>%swag_controller.plugin_dir%</argument>
             <argument type="service" id="template"/>
             <tag name="shopware.event_subscriber"/>

--- a/exampleplugins/5.2/SwagController/Subscriber/TemplateRegistration.php
+++ b/exampleplugins/5.2/SwagController/Subscriber/TemplateRegistration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SwagProductListing\Subscriber;
+namespace SwagController\Subscriber;
 
 use Enlight\Event\SubscriberInterface;
 


### PR DESCRIPTION
Wrong namespace is used in the SwagController example