### PR TITLE
NTR - Remove information about the considerTaxInput parameter from th…

### DIFF
--- a/source/developers-guide/rest-api/api-resource-article/index.md
+++ b/source/developers-guide/rest-api/api-resource-article/index.md
@@ -110,18 +110,16 @@ The following table shows the fields, types and original objects of this array.
 
 Optional parameters can be provided:
 * language `id` or `locale` (from `s_core_locales`). If used, the returned info will be provided in the specified language (if available)
-* `considerTaxInput`: By default, all returned prices are net values. If the boolean `considerTaxInput` is set to true, gross values will be returned instead.
 
 | Identifier       | Parameter | DB column              | Example call                             |
 |------------------|-----------|------------------------|------------------------------------------|
 | language         | id        | s_core_locales         | /api/articles/language=de_DE             |
-| considerTaxInput | boolean   |                        | /api/articles/considerTaxInput=true      |
 
 You can use one or more of these parameters together.
 
 Here is an example of a parametrized URL:
 
-* **http://my-shop-url/api/articles/considerTaxInput=true&language=de_DE**
+* **http://my-shop-url/api/articles/?language=de_DE**
 
 #### Return Value
 


### PR DESCRIPTION
…e product listing section

---

This information is already present above and (falsely) implies, that a `GET` request to `/articles` will include prices for each product listed in the response.