### PR TITLE
corrected doc for elastic search

### DIFF
--- a/source/developers-guide/elasticsearch/index.md
+++ b/source/developers-guide/elasticsearch/index.md
@@ -1191,7 +1191,7 @@ class SearchTermQueryBuilder implements SearchTermQueryBuilderInterface
         $query = $this->decoratedQueryBuilder->buildQuery($context, $term);
 
         $matchQuery = new MultiMatchQuery(
-            ['attributes.properties.swag_es_product.my_name'],
+            ['attributes.swag_es_product.my_name'],
             $term
         );
         $query->add($matchQuery, BoolQuery::SHOULD);
@@ -1262,7 +1262,7 @@ The new `SearchTermQueryBuilder` now adds an additional `MultiMatchQuery` for th
 
 ```php
 $matchQuery = new MultiMatchQuery(
-    ['attributes.properties.swag_es_product.my_name'],
+    ['attributes.swag_es_product.my_name'],
     $term
 );
 $query->add($matchQuery, BoolQuery::SHOULD);
@@ -1320,7 +1320,7 @@ ONGR\ElasticsearchDSL\Query\BoolQuery Object
                                 (
                                     [fields] => Array
                                         (
-                                            [0] => attributes.properties.swag_es_product.my_name
+                                            [0] => attributes.swag_es_product.my_name
                                         )
 
                                     [query] => Spachtel


### PR DESCRIPTION
corrected doc for addressing of newly created mapping for elastic search, as the properties attributes have to be ignored when addressing the field

I had massive problems to address attributes created over the free text management inside the elastic search queries generated by using the ONGR Framework.
I noticed, that this .properties is too much. It's an attribute inside the mapping, but it does not work to address the field with it. By addressing it has to be removed.