### PR TITLE
Update `shipped` data type

### DIFF
--- a/source/developers-guide/rest-api/models/index.md
+++ b/source/developers-guide/rest-api/models/index.md
@@ -615,7 +615,7 @@ The field `path` has to be the local path to the image, seen from the root of th
 | price                  | double                  |                                                            |
 | quantity              | integer               |                                                            |
 | articleName          | string                     |                                                            |
-| shipped              | boolean               |                                                            |
+| shipped              | integer               |                                                            |
 | shippedGroup          | integer               |                                                            |
 | releaseDate          | date/time               |                                                            |
 | mode                  | integer               |                                                            |


### PR DESCRIPTION
The data type of the shipped value is wrong in the developers documentation.
The data type should be integer:
https://github.com/shopware/shopware/blob/c8558e5da009b1b608d77f1decff6484bbe52cf0/engine/Shopware/Models/Order/Detail.php#L206-L211