### PR TITLE
fix: spelling of csrfProtection

### DIFF
--- a/source/developers-guide/csrf-protection/index.md
+++ b/source/developers-guide/csrf-protection/index.md
@@ -109,7 +109,7 @@ In some cases, you might want to disable the protection for the backend or front
 
 ```php
 ...
-'csrfProtection' => [
+'csrfprotection' => [
     'frontend' => false,
     'backend' => false
 ],


### PR DESCRIPTION
This was changed to csrfprotection (all lower-case) in shopware/shopware commit: 58fc7c3

Related: https://github.com/shopware/shopware/commit/58fc7c3bcc7a99c4af1b67bb6377995bed3752c3